### PR TITLE
Speedup sandybridge processors by asm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,6 @@ COPYING
 *.la
 *.o
 *.lo
+*.idb
 
 *.exe

--- a/SMP/libgmp-sandybridge.vcxproj
+++ b/SMP/libgmp-sandybridge.vcxproj
@@ -878,9 +878,6 @@
     <ClInclude Include="x86_64\mpn\perfsqr.h" />
   </ItemGroup>
   <ItemGroup>
-    <YASM Include="yasm\addmul_2.asm">
-      <IncludePaths>yasm</IncludePaths>
-    </YASM>
     <YASM Include="yasm\add_err1_n.asm">
       <IncludePaths>yasm</IncludePaths>
     </YASM>
@@ -909,9 +906,6 @@
       <IncludePaths>yasm</IncludePaths>
     </YASM>
     <YASM Include="yasm\mulmid_basecase.asm">
-      <IncludePaths>yasm</IncludePaths>
-    </YASM>
-    <YASM Include="yasm\mul_2.asm">
       <IncludePaths>yasm</IncludePaths>
     </YASM>
     <YASM Include="yasm\sandybridge\addmul_1.asm">

--- a/SMP/libgmp-sandybridge.vcxproj
+++ b/SMP/libgmp-sandybridge.vcxproj
@@ -44,7 +44,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\assert.c" />
-    <ClCompile Include="..\compat.c" />
     <ClCompile Include="..\errno.c" />
     <ClCompile Include="..\extract-dbl.c" />
     <ClCompile Include="..\invalid.c" />
@@ -249,12 +248,8 @@
       <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\add.c" />
-    <ClCompile Include="..\mpn\generic\addmul_1.c" />
     <ClCompile Include="..\mpn\generic\add_1.c" />
-    <ClCompile Include="..\mpn\generic\add_err1_n.c" />
-    <ClCompile Include="..\mpn\generic\add_err2_n.c" />
     <ClCompile Include="..\mpn\generic\add_err3_n.c" />
-    <ClCompile Include="..\mpn\generic\add_n.c" />
     <ClCompile Include="..\mpn\generic\add_n_sub_n.c" />
     <ClCompile Include="..\mpn\generic\bdiv_dbm1c.c" />
     <ClCompile Include="..\mpn\generic\bdiv_q.c" />
@@ -273,20 +268,15 @@
     <ClCompile Include="..\mpn\generic\cnd_swap.c" />
     <ClCompile Include="..\mpn\generic\com.c" />
     <ClCompile Include="..\mpn\generic\comb_tables.c" />
-    <ClCompile Include="..\mpn\generic\copyd.c" />
-    <ClCompile Include="..\mpn\generic\copyi.c" />
     <ClCompile Include="..\mpn\generic\dcpi1_bdiv_q.c" />
     <ClCompile Include="..\mpn\generic\dcpi1_bdiv_qr.c" />
     <ClCompile Include="..\mpn\generic\dcpi1_divappr_q.c" />
     <ClCompile Include="..\mpn\generic\dcpi1_div_q.c" />
     <ClCompile Include="..\mpn\generic\dcpi1_div_qr.c" />
-    <ClCompile Include="..\mpn\generic\diveby3.c" />
     <ClCompile Include="..\mpn\generic\divexact.c" />
-    <ClCompile Include="..\mpn\generic\dive_1.c" />
     <ClCompile Include="..\mpn\generic\divis.c" />
     <ClCompile Include="..\mpn\generic\divrem.c" />
     <ClCompile Include="..\mpn\generic\divrem_1.c" />
-    <ClCompile Include="..\mpn\generic\divrem_2.c" />
     <ClCompile Include="..\mpn\generic\div_q.c" />
     <ClCompile Include="..\mpn\generic\div_qr_1.c" />
     <ClCompile Include="..\mpn\generic\div_qr_1n_pi1.c" />
@@ -324,15 +314,9 @@
     <ClCompile Include="..\mpn\generic\jacbase.c" />
     <ClCompile Include="..\mpn\generic\jacobi.c" />
     <ClCompile Include="..\mpn\generic\jacobi_2.c" />
-    <ClCompile Include="..\mpn\generic\lshift.c" />
-    <ClCompile Include="..\mpn\generic\lshiftc.c" />
     <ClCompile Include="..\mpn\generic\matrix22_mul.c" />
     <ClCompile Include="..\mpn\generic\matrix22_mul1_inverse_vector.c" />
-    <ClCompile Include="..\mpn\generic\mode1o.c" />
     <ClCompile Include="..\mpn\generic\mod_1.c" />
-    <ClCompile Include="..\mpn\generic\mod_1_1.c" />
-    <ClCompile Include="..\mpn\generic\mod_1_2.c" />
-    <ClCompile Include="..\mpn\generic\mod_1_3.c" />
     <ClCompile Include="..\mpn\generic\mod_1_4.c" />
     <ClCompile Include="..\mpn\generic\mod_34lsub1.c" />
     <ClCompile Include="..\mpn\generic\mul.c">
@@ -341,10 +325,8 @@
     <ClCompile Include="..\mpn\generic\mullo_basecase.c" />
     <ClCompile Include="..\mpn\generic\mullo_n.c" />
     <ClCompile Include="..\mpn\generic\mulmid.c" />
-    <ClCompile Include="..\mpn\generic\mulmid_basecase.c" />
     <ClCompile Include="..\mpn\generic\mulmid_n.c" />
     <ClCompile Include="..\mpn\generic\mulmod_bnm1.c" />
-    <ClCompile Include="..\mpn\generic\mul_1.c" />
     <ClCompile Include="..\mpn\generic\mul_basecase.c" />
     <ClCompile Include="..\mpn\generic\mul_fft.c" />
     <ClCompile Include="..\mpn\generic\mul_n.c" />
@@ -362,16 +344,13 @@
     <ClCompile Include="..\mpn\generic\powlo.c" />
     <ClCompile Include="..\mpn\generic\powm.c" />
     <ClCompile Include="..\mpn\generic\pow_1.c" />
-    <ClCompile Include="..\mpn\generic\pre_divrem_1.c" />
     <ClCompile Include="..\mpn\generic\pre_mod_1.c" />
     <ClCompile Include="..\mpn\generic\random.c" />
     <ClCompile Include="..\mpn\generic\random2.c" />
-    <ClCompile Include="..\mpn\generic\redc_1.c" />
     <ClCompile Include="..\mpn\generic\redc_2.c" />
     <ClCompile Include="..\mpn\generic\redc_n.c" />
     <ClCompile Include="..\mpn\generic\remove.c" />
     <ClCompile Include="..\mpn\generic\rootrem.c" />
-    <ClCompile Include="..\mpn\generic\rshift.c" />
     <ClCompile Include="..\mpn\generic\sbpi1_bdiv_q.c" />
     <ClCompile Include="..\mpn\generic\sbpi1_bdiv_qr.c" />
     <ClCompile Include="..\mpn\generic\sbpi1_divappr_q.c" />
@@ -393,16 +372,11 @@
     <ClCompile Include="..\mpn\generic\sqrlo_basecase.c" />
     <ClCompile Include="..\mpn\generic\sqrmod_bnm1.c" />
     <ClCompile Include="..\mpn\generic\sqrtrem.c" />
-    <ClCompile Include="..\mpn\generic\sqr_basecase.c" />
     <ClCompile Include="..\mpn\generic\sub.c">
       <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\submul_1.c" />
     <ClCompile Include="..\mpn\generic\sub_1.c" />
-    <ClCompile Include="..\mpn\generic\sub_err1_n.c" />
-    <ClCompile Include="..\mpn\generic\sub_err2_n.c" />
     <ClCompile Include="..\mpn\generic\sub_err3_n.c" />
-    <ClCompile Include="..\mpn\generic\sub_n.c" />
     <ClCompile Include="..\mpn\generic\tdiv_qr.c" />
     <ClCompile Include="..\mpn\generic\toom22_mul.c" />
     <ClCompile Include="..\mpn\generic\toom2_sqr.c" />
@@ -869,22 +843,12 @@
     <ClCompile Include="..\scanf\vsscanf.c" />
     <ClCompile Include="..\tal-reent.c" />
     <ClCompile Include="..\version.c" />
-    <ClCompile Include="mpn\andn_n.c" />
-    <ClCompile Include="mpn\and_n.c" />
-    <ClCompile Include="mpn\hamdist.c" />
-    <ClCompile Include="mpn\iorn_n.c" />
-    <ClCompile Include="mpn\ior_n.c" />
-    <ClCompile Include="mpn\nand_n.c" />
-    <ClCompile Include="mpn\nior_n.c" />
-    <ClCompile Include="mpn\popcount.c" />
     <ClCompile Include="mpn\sec_add_1.c" />
     <ClCompile Include="mpn\sec_div_qr.c" />
     <ClCompile Include="mpn\sec_div_r.c" />
     <ClCompile Include="mpn\sec_pi1_div_qr.c" />
     <ClCompile Include="mpn\sec_pi1_div_r.c" />
     <ClCompile Include="mpn\sec_sub_1.c" />
-    <ClCompile Include="mpn\xnor_n.c" />
-    <ClCompile Include="mpn\xor_n.c" />
     <ClCompile Include="x86\mpn\fib_table.c">
       <ExcludedFromBuild Condition="'$(Platform)'=='x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -912,6 +876,164 @@
     <ClInclude Include="version.h" />
     <ClInclude Include="x86\mpn\perfsqr.h" />
     <ClInclude Include="x86_64\mpn\perfsqr.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <YASM Include="yasm\addmul_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\add_err1_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\add_err2_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\divexact_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\divexact_by3c.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\divexact_byfobm1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\divrem_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\divrem_euclidean_qr_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\divrem_euclidean_qr_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\modexact_1c_odd.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\mulmid_basecase.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\mul_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\addmul_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\addmul_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\add_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\andn_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\and_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\com_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\copyd.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\copyi.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\divexact_byff.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\divrem_hensel_qr_1_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\hamdist.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\iorn_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\ior_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\karaadd.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\karasub.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\lshift.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\lshift1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\lshiftc.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mod_1_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mod_1_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mod_1_3.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mul_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mul_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\nand_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\nior_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\popcount.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\redc_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\rshift.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\rsh_divrem_hensel_qr_1_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\rsh_divrem_hensel_qr_1_2.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\store.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\submul_1.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\sub_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\xnor_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sandybridge\xor_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sqr_basecase.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sub_err1_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\sub_err2_n.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\udiv_qrnnd.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
+    <YASM Include="yasm\umul_ppmm.asm">
+      <IncludePaths>yasm</IncludePaths>
+    </YASM>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{29DCC424-3CB3-4452-81A4-81A6A35127EC}</ProjectGuid>
@@ -993,6 +1115,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
+    <Import Project="yasm\vsyasm.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -1966,5 +2089,6 @@ del /f /q $(OutDir)\licenses\gmp.txt
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
+    <Import Project="yasm\vsyasm.targets" />
   </ImportGroup>
 </Project>

--- a/SMP/libgmp-sandybridge.vcxproj
+++ b/SMP/libgmp-sandybridge.vcxproj
@@ -1,0 +1,1970 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="DebugDLL|Win32">
+      <Configuration>DebugDLL</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="DebugDLL|x64">
+      <Configuration>DebugDLL</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseDLL|Win32">
+      <Configuration>ReleaseDLL</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseDLL|x64">
+      <Configuration>ReleaseDLL</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseLTO|Win32">
+      <Configuration>ReleaseLTO</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseLTO|x64">
+      <Configuration>ReleaseLTO</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\assert.c" />
+    <ClCompile Include="..\compat.c" />
+    <ClCompile Include="..\errno.c" />
+    <ClCompile Include="..\extract-dbl.c" />
+    <ClCompile Include="..\invalid.c" />
+    <ClCompile Include="..\memory.c" />
+    <ClCompile Include="..\mpf\abs.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\add.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\add_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\ceilfloor.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\clear.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\clears.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_d.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_si.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_z.c" />
+    <ClCompile Include="..\mpf\div.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\div_2exp.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\div_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\dump.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\eq.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_sint.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_slong.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_sshort.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_uint.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_ulong.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_ushort.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_d.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_dfl_prec.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_d_2exp.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_prc.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_si.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_str.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\init.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\init2.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\inits.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\inp_str.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\int_p.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_d.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_si.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_str.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\mul.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\mul_2exp.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\mul_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\neg.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\out_str.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\pow_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\random2.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\reldiff.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_d.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_dfl_prec.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_prc.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_prc_raw.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_q.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_si.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_str.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_z.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\size.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sqrt.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sqrt_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sub.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sub_ui.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\swap.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\trunc.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\ui_div.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\ui_sub.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpf\urandomb.c">
+      <ObjectFileName>$(IntDir)\mpf_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add.c" />
+    <ClCompile Include="..\mpn\generic\addmul_1.c" />
+    <ClCompile Include="..\mpn\generic\add_1.c" />
+    <ClCompile Include="..\mpn\generic\add_err1_n.c" />
+    <ClCompile Include="..\mpn\generic\add_err2_n.c" />
+    <ClCompile Include="..\mpn\generic\add_err3_n.c" />
+    <ClCompile Include="..\mpn\generic\add_n.c" />
+    <ClCompile Include="..\mpn\generic\add_n_sub_n.c" />
+    <ClCompile Include="..\mpn\generic\bdiv_dbm1c.c" />
+    <ClCompile Include="..\mpn\generic\bdiv_q.c" />
+    <ClCompile Include="..\mpn\generic\bdiv_qr.c" />
+    <ClCompile Include="..\mpn\generic\bdiv_q_1.c" />
+    <ClCompile Include="..\mpn\generic\binvert.c" />
+    <ClCompile Include="..\mpn\generic\broot.c" />
+    <ClCompile Include="..\mpn\generic\brootinv.c" />
+    <ClCompile Include="..\mpn\generic\bsqrt.c" />
+    <ClCompile Include="..\mpn\generic\bsqrtinv.c" />
+    <ClCompile Include="..\mpn\generic\cmp.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\cnd_add_n.c" />
+    <ClCompile Include="..\mpn\generic\cnd_sub_n.c" />
+    <ClCompile Include="..\mpn\generic\cnd_swap.c" />
+    <ClCompile Include="..\mpn\generic\com.c" />
+    <ClCompile Include="..\mpn\generic\comb_tables.c" />
+    <ClCompile Include="..\mpn\generic\copyd.c" />
+    <ClCompile Include="..\mpn\generic\copyi.c" />
+    <ClCompile Include="..\mpn\generic\dcpi1_bdiv_q.c" />
+    <ClCompile Include="..\mpn\generic\dcpi1_bdiv_qr.c" />
+    <ClCompile Include="..\mpn\generic\dcpi1_divappr_q.c" />
+    <ClCompile Include="..\mpn\generic\dcpi1_div_q.c" />
+    <ClCompile Include="..\mpn\generic\dcpi1_div_qr.c" />
+    <ClCompile Include="..\mpn\generic\diveby3.c" />
+    <ClCompile Include="..\mpn\generic\divexact.c" />
+    <ClCompile Include="..\mpn\generic\dive_1.c" />
+    <ClCompile Include="..\mpn\generic\divis.c" />
+    <ClCompile Include="..\mpn\generic\divrem.c" />
+    <ClCompile Include="..\mpn\generic\divrem_1.c" />
+    <ClCompile Include="..\mpn\generic\divrem_2.c" />
+    <ClCompile Include="..\mpn\generic\div_q.c" />
+    <ClCompile Include="..\mpn\generic\div_qr_1.c" />
+    <ClCompile Include="..\mpn\generic\div_qr_1n_pi1.c" />
+    <ClCompile Include="..\mpn\generic\div_qr_1n_pi2.c" />
+    <ClCompile Include="..\mpn\generic\div_qr_1u_pi2.c" />
+    <ClCompile Include="..\mpn\generic\div_qr_2.c" />
+    <ClCompile Include="..\mpn\generic\div_qr_2n_pi1.c" />
+    <ClCompile Include="..\mpn\generic\div_qr_2u_pi1.c" />
+    <ClCompile Include="..\mpn\generic\dump.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\fib2_ui.c" />
+    <ClCompile Include="..\mpn\generic\gcd.c" />
+    <ClCompile Include="..\mpn\generic\gcdext.c" />
+    <ClCompile Include="..\mpn\generic\gcdext_1.c" />
+    <ClCompile Include="..\mpn\generic\gcdext_lehmer.c" />
+    <ClCompile Include="..\mpn\generic\gcd_1.c" />
+    <ClCompile Include="..\mpn\generic\gcd_subdiv_step.c" />
+    <ClCompile Include="..\mpn\generic\get_d.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\get_str.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd.c" />
+    <ClCompile Include="..\mpn\generic\hgcd2.c" />
+    <ClCompile Include="..\mpn\generic\hgcd2_jacobi.c" />
+    <ClCompile Include="..\mpn\generic\hgcd_appr.c" />
+    <ClCompile Include="..\mpn\generic\hgcd_jacobi.c" />
+    <ClCompile Include="..\mpn\generic\hgcd_matrix.c" />
+    <ClCompile Include="..\mpn\generic\hgcd_reduce.c" />
+    <ClCompile Include="..\mpn\generic\hgcd_step.c" />
+    <ClCompile Include="..\mpn\generic\invert.c" />
+    <ClCompile Include="..\mpn\generic\invertappr.c" />
+    <ClCompile Include="..\mpn\generic\jacbase.c" />
+    <ClCompile Include="..\mpn\generic\jacobi.c" />
+    <ClCompile Include="..\mpn\generic\jacobi_2.c" />
+    <ClCompile Include="..\mpn\generic\lshift.c" />
+    <ClCompile Include="..\mpn\generic\lshiftc.c" />
+    <ClCompile Include="..\mpn\generic\matrix22_mul.c" />
+    <ClCompile Include="..\mpn\generic\matrix22_mul1_inverse_vector.c" />
+    <ClCompile Include="..\mpn\generic\mode1o.c" />
+    <ClCompile Include="..\mpn\generic\mod_1.c" />
+    <ClCompile Include="..\mpn\generic\mod_1_1.c" />
+    <ClCompile Include="..\mpn\generic\mod_1_2.c" />
+    <ClCompile Include="..\mpn\generic\mod_1_3.c" />
+    <ClCompile Include="..\mpn\generic\mod_1_4.c" />
+    <ClCompile Include="..\mpn\generic\mod_34lsub1.c" />
+    <ClCompile Include="..\mpn\generic\mul.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mullo_basecase.c" />
+    <ClCompile Include="..\mpn\generic\mullo_n.c" />
+    <ClCompile Include="..\mpn\generic\mulmid.c" />
+    <ClCompile Include="..\mpn\generic\mulmid_basecase.c" />
+    <ClCompile Include="..\mpn\generic\mulmid_n.c" />
+    <ClCompile Include="..\mpn\generic\mulmod_bnm1.c" />
+    <ClCompile Include="..\mpn\generic\mul_1.c" />
+    <ClCompile Include="..\mpn\generic\mul_basecase.c" />
+    <ClCompile Include="..\mpn\generic\mul_fft.c" />
+    <ClCompile Include="..\mpn\generic\mul_n.c" />
+    <ClCompile Include="..\mpn\generic\mu_bdiv_q.c" />
+    <ClCompile Include="..\mpn\generic\mu_bdiv_qr.c" />
+    <ClCompile Include="..\mpn\generic\mu_divappr_q.c" />
+    <ClCompile Include="..\mpn\generic\mu_div_q.c" />
+    <ClCompile Include="..\mpn\generic\mu_div_qr.c" />
+    <ClCompile Include="..\mpn\generic\neg.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\nussbaumer_mul.c" />
+    <ClCompile Include="..\mpn\generic\perfpow.c" />
+    <ClCompile Include="..\mpn\generic\perfsqr.c" />
+    <ClCompile Include="..\mpn\generic\powlo.c" />
+    <ClCompile Include="..\mpn\generic\powm.c" />
+    <ClCompile Include="..\mpn\generic\pow_1.c" />
+    <ClCompile Include="..\mpn\generic\pre_divrem_1.c" />
+    <ClCompile Include="..\mpn\generic\pre_mod_1.c" />
+    <ClCompile Include="..\mpn\generic\random.c" />
+    <ClCompile Include="..\mpn\generic\random2.c" />
+    <ClCompile Include="..\mpn\generic\redc_1.c" />
+    <ClCompile Include="..\mpn\generic\redc_2.c" />
+    <ClCompile Include="..\mpn\generic\redc_n.c" />
+    <ClCompile Include="..\mpn\generic\remove.c" />
+    <ClCompile Include="..\mpn\generic\rootrem.c" />
+    <ClCompile Include="..\mpn\generic\rshift.c" />
+    <ClCompile Include="..\mpn\generic\sbpi1_bdiv_q.c" />
+    <ClCompile Include="..\mpn\generic\sbpi1_bdiv_qr.c" />
+    <ClCompile Include="..\mpn\generic\sbpi1_divappr_q.c" />
+    <ClCompile Include="..\mpn\generic\sbpi1_div_q.c" />
+    <ClCompile Include="..\mpn\generic\sbpi1_div_qr.c" />
+    <ClCompile Include="..\mpn\generic\scan0.c" />
+    <ClCompile Include="..\mpn\generic\scan1.c" />
+    <ClCompile Include="..\mpn\generic\sec_invert.c" />
+    <ClCompile Include="..\mpn\generic\sec_mul.c" />
+    <ClCompile Include="..\mpn\generic\sec_powm.c" />
+    <ClCompile Include="..\mpn\generic\sec_sqr.c" />
+    <ClCompile Include="..\mpn\generic\sec_tabselect.c" />
+    <ClCompile Include="..\mpn\generic\set_str.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sizeinbase.c" />
+    <ClCompile Include="..\mpn\generic\sqr.c" />
+    <ClCompile Include="..\mpn\generic\sqrlo.c" />
+    <ClCompile Include="..\mpn\generic\sqrlo_basecase.c" />
+    <ClCompile Include="..\mpn\generic\sqrmod_bnm1.c" />
+    <ClCompile Include="..\mpn\generic\sqrtrem.c" />
+    <ClCompile Include="..\mpn\generic\sqr_basecase.c" />
+    <ClCompile Include="..\mpn\generic\sub.c">
+      <ObjectFileName>$(IntDir)\mpn_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\submul_1.c" />
+    <ClCompile Include="..\mpn\generic\sub_1.c" />
+    <ClCompile Include="..\mpn\generic\sub_err1_n.c" />
+    <ClCompile Include="..\mpn\generic\sub_err2_n.c" />
+    <ClCompile Include="..\mpn\generic\sub_err3_n.c" />
+    <ClCompile Include="..\mpn\generic\sub_n.c" />
+    <ClCompile Include="..\mpn\generic\tdiv_qr.c" />
+    <ClCompile Include="..\mpn\generic\toom22_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom2_sqr.c" />
+    <ClCompile Include="..\mpn\generic\toom32_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom33_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom3_sqr.c" />
+    <ClCompile Include="..\mpn\generic\toom42_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom42_mulmid.c" />
+    <ClCompile Include="..\mpn\generic\toom43_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom44_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom4_sqr.c" />
+    <ClCompile Include="..\mpn\generic\toom52_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom53_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom54_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom62_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom63_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom6h_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom6_sqr.c" />
+    <ClCompile Include="..\mpn\generic\toom8h_mul.c" />
+    <ClCompile Include="..\mpn\generic\toom8_sqr.c" />
+    <ClCompile Include="..\mpn\generic\toom_couple_handling.c" />
+    <ClCompile Include="..\mpn\generic\toom_eval_dgr3_pm1.c" />
+    <ClCompile Include="..\mpn\generic\toom_eval_dgr3_pm2.c" />
+    <ClCompile Include="..\mpn\generic\toom_eval_pm1.c" />
+    <ClCompile Include="..\mpn\generic\toom_eval_pm2.c" />
+    <ClCompile Include="..\mpn\generic\toom_eval_pm2exp.c" />
+    <ClCompile Include="..\mpn\generic\toom_eval_pm2rexp.c" />
+    <ClCompile Include="..\mpn\generic\toom_interpolate_12pts.c" />
+    <ClCompile Include="..\mpn\generic\toom_interpolate_16pts.c" />
+    <ClCompile Include="..\mpn\generic\toom_interpolate_5pts.c" />
+    <ClCompile Include="..\mpn\generic\toom_interpolate_6pts.c" />
+    <ClCompile Include="..\mpn\generic\toom_interpolate_7pts.c" />
+    <ClCompile Include="..\mpn\generic\toom_interpolate_8pts.c" />
+    <ClCompile Include="..\mpn\generic\trialdiv.c" />
+    <ClCompile Include="..\mpn\generic\zero.c" />
+    <ClCompile Include="..\mpq\abs.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\aors.c" />
+    <ClCompile Include="..\mpq\canonicalize.c" />
+    <ClCompile Include="..\mpq\clear.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\clears.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\cmp.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\cmp_si.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\cmp_ui.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\div.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\equal.c" />
+    <ClCompile Include="..\mpq\get_d.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\get_den.c" />
+    <ClCompile Include="..\mpq\get_num.c" />
+    <ClCompile Include="..\mpq\get_str.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\init.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\inits.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\inp_str.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\inv.c" />
+    <ClCompile Include="..\mpq\md_2exp.c" />
+    <ClCompile Include="..\mpq\mul.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\neg.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\out_str.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_d.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_den.c" />
+    <ClCompile Include="..\mpq\set_f.c" />
+    <ClCompile Include="..\mpq\set_num.c" />
+    <ClCompile Include="..\mpq\set_si.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_str.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_ui.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_z.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpq\swap.c">
+      <ObjectFileName>$(IntDir)\mpq_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\2fac_ui.c" />
+    <ClCompile Include="..\mpz\abs.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\add.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\add_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\and.c" />
+    <ClCompile Include="..\mpz\aorsmul.c" />
+    <ClCompile Include="..\mpz\aorsmul_i.c" />
+    <ClCompile Include="..\mpz\array_init.c" />
+    <ClCompile Include="..\mpz\bin_ui.c" />
+    <ClCompile Include="..\mpz\bin_uiui.c" />
+    <ClCompile Include="..\mpz\cdiv_q.c" />
+    <ClCompile Include="..\mpz\cdiv_qr.c" />
+    <ClCompile Include="..\mpz\cdiv_qr_ui.c" />
+    <ClCompile Include="..\mpz\cdiv_q_ui.c" />
+    <ClCompile Include="..\mpz\cdiv_r.c" />
+    <ClCompile Include="..\mpz\cdiv_r_ui.c" />
+    <ClCompile Include="..\mpz\cdiv_ui.c" />
+    <ClCompile Include="..\mpz\cfdiv_q_2exp.c" />
+    <ClCompile Include="..\mpz\cfdiv_r_2exp.c" />
+    <ClCompile Include="..\mpz\clear.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\clears.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\clrbit.c" />
+    <ClCompile Include="..\mpz\cmp.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmpabs.c" />
+    <ClCompile Include="..\mpz\cmpabs_d.c" />
+    <ClCompile Include="..\mpz\cmpabs_ui.c" />
+    <ClCompile Include="..\mpz\cmp_d.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmp_si.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmp_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\com.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\combit.c" />
+    <ClCompile Include="..\mpz\cong.c" />
+    <ClCompile Include="..\mpz\cong_2exp.c" />
+    <ClCompile Include="..\mpz\cong_ui.c" />
+    <ClCompile Include="..\mpz\divegcd.c" />
+    <ClCompile Include="..\mpz\divexact.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\dive_ui.c" />
+    <ClCompile Include="..\mpz\divis.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\divis_2exp.c" />
+    <ClCompile Include="..\mpz\divis_ui.c" />
+    <ClCompile Include="..\mpz\dump.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\export.c" />
+    <ClCompile Include="..\mpz\fac_ui.c" />
+    <ClCompile Include="..\mpz\fdiv_q.c" />
+    <ClCompile Include="..\mpz\fdiv_qr.c" />
+    <ClCompile Include="..\mpz\fdiv_qr_ui.c" />
+    <ClCompile Include="..\mpz\fdiv_q_ui.c" />
+    <ClCompile Include="..\mpz\fdiv_r.c" />
+    <ClCompile Include="..\mpz\fdiv_r_ui.c" />
+    <ClCompile Include="..\mpz\fdiv_ui.c" />
+    <ClCompile Include="..\mpz\fib2_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fib_ui.c" />
+    <ClCompile Include="..\mpz\fits_sint.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_slong.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_sshort.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_uint.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_ulong.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_ushort.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\gcd.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\gcdext.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\gcd_ui.c" />
+    <ClCompile Include="..\mpz\getlimbn.c" />
+    <ClCompile Include="..\mpz\get_d.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_d_2exp.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_si.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_str.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\hamdist.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\import.c" />
+    <ClCompile Include="..\mpz\init.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\init2.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\inits.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\inp_raw.c" />
+    <ClCompile Include="..\mpz\inp_str.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\invert.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\ior.c" />
+    <ClCompile Include="..\mpz\iset.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_d.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_si.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_str.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\jacobi.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\kronsz.c" />
+    <ClCompile Include="..\mpz\kronuz.c" />
+    <ClCompile Include="..\mpz\kronzs.c" />
+    <ClCompile Include="..\mpz\kronzu.c" />
+    <ClCompile Include="..\mpz\lcm.c" />
+    <ClCompile Include="..\mpz\lcm_ui.c" />
+    <ClCompile Include="..\mpz\limbs_finish.c" />
+    <ClCompile Include="..\mpz\limbs_modify.c" />
+    <ClCompile Include="..\mpz\limbs_read.c" />
+    <ClCompile Include="..\mpz\limbs_write.c" />
+    <ClCompile Include="..\mpz\lucnum2_ui.c" />
+    <ClCompile Include="..\mpz\lucnum_ui.c" />
+    <ClCompile Include="..\mpz\mfac_uiui.c" />
+    <ClCompile Include="..\mpz\millerrabin.c" />
+    <ClCompile Include="..\mpz\mod.c" />
+    <ClCompile Include="..\mpz\mul.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mul_2exp.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mul_si.c" />
+    <ClCompile Include="..\mpz\mul_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\neg.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\nextprime.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\n_pow_ui.c" />
+    <ClCompile Include="..\mpz\oddfac_1.c" />
+    <ClCompile Include="..\mpz\out_raw.c" />
+    <ClCompile Include="..\mpz\out_str.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\perfpow.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\perfsqr.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\popcount.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\powm.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\powm_sec.c" />
+    <ClCompile Include="..\mpz\powm_ui.c" />
+    <ClCompile Include="..\mpz\pow_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\pprime_p.c" />
+    <ClCompile Include="..\mpz\primorial_ui.c" />
+    <ClCompile Include="..\mpz\prodlimbs.c" />
+    <ClCompile Include="..\mpz\random.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\random2.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\realloc.c" />
+    <ClCompile Include="..\mpz\realloc2.c" />
+    <ClCompile Include="..\mpz\remove.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\roinit_n.c" />
+    <ClCompile Include="..\mpz\root.c" />
+    <ClCompile Include="..\mpz\rootrem.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\rrandomb.c" />
+    <ClCompile Include="..\mpz\scan0.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\scan1.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\setbit.c" />
+    <ClCompile Include="..\mpz\set_d.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_f.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_q.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_si.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_str.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\size.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sizeinbase.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sqrt.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sqrtrem.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sub.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sub_ui.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\swap.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_q.c" />
+    <ClCompile Include="..\mpz\tdiv_qr.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_qr_ui.c" />
+    <ClCompile Include="..\mpz\tdiv_q_2exp.c" />
+    <ClCompile Include="..\mpz\tdiv_q_ui.c" />
+    <ClCompile Include="..\mpz\tdiv_r.c" />
+    <ClCompile Include="..\mpz\tdiv_r_2exp.c" />
+    <ClCompile Include="..\mpz\tdiv_r_ui.c" />
+    <ClCompile Include="..\mpz\tdiv_ui.c" />
+    <ClCompile Include="..\mpz\tstbit.c" />
+    <ClCompile Include="..\mpz\ui_pow_ui.c" />
+    <ClCompile Include="..\mpz\ui_sub.c">
+      <ObjectFileName>$(IntDir)\mpz_%(Filename).obj</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\mpz\urandomb.c" />
+    <ClCompile Include="..\mpz\urandomm.c" />
+    <ClCompile Include="..\mpz\xor.c" />
+    <ClCompile Include="..\mp_bpl.c" />
+    <ClCompile Include="..\mp_clz_tab.c" />
+    <ClCompile Include="..\mp_dv_tab.c" />
+    <ClCompile Include="..\mp_get_fns.c" />
+    <ClCompile Include="..\mp_minv_tab.c" />
+    <ClCompile Include="..\mp_set_fns.c" />
+    <ClCompile Include="..\nextprime.c" />
+    <ClCompile Include="..\primesieve.c" />
+    <ClCompile Include="..\printf\asprintf.c" />
+    <ClCompile Include="..\printf\asprntffuns.c" />
+    <ClCompile Include="..\printf\doprnt.c" />
+    <ClCompile Include="..\printf\doprntf.c" />
+    <ClCompile Include="..\printf\doprnti.c" />
+    <ClCompile Include="..\printf\fprintf.c" />
+    <ClCompile Include="..\printf\obprintf.c" />
+    <ClCompile Include="..\printf\obprntffuns.c" />
+    <ClCompile Include="..\printf\obvprintf.c" />
+    <ClCompile Include="..\printf\printf.c" />
+    <ClCompile Include="..\printf\printffuns.c" />
+    <ClCompile Include="..\printf\repl-vsnprintf.c" />
+    <ClCompile Include="..\printf\snprintf.c" />
+    <ClCompile Include="..\printf\snprntffuns.c" />
+    <ClCompile Include="..\printf\sprintf.c" />
+    <ClCompile Include="..\printf\sprintffuns.c" />
+    <ClCompile Include="..\printf\vasprintf.c" />
+    <ClCompile Include="..\printf\vfprintf.c" />
+    <ClCompile Include="..\printf\vprintf.c" />
+    <ClCompile Include="..\printf\vsnprintf.c" />
+    <ClCompile Include="..\printf\vsprintf.c" />
+    <ClCompile Include="..\rand\rand.c" />
+    <ClCompile Include="..\rand\randbui.c" />
+    <ClCompile Include="..\rand\randclr.c" />
+    <ClCompile Include="..\rand\randdef.c" />
+    <ClCompile Include="..\rand\randiset.c" />
+    <ClCompile Include="..\rand\randlc2s.c" />
+    <ClCompile Include="..\rand\randlc2x.c" />
+    <ClCompile Include="..\rand\randmt.c" />
+    <ClCompile Include="..\rand\randmts.c" />
+    <ClCompile Include="..\rand\randmui.c" />
+    <ClCompile Include="..\rand\rands.c" />
+    <ClCompile Include="..\rand\randsd.c" />
+    <ClCompile Include="..\rand\randsdui.c" />
+    <ClCompile Include="..\scanf\doscan.c" />
+    <ClCompile Include="..\scanf\fscanf.c" />
+    <ClCompile Include="..\scanf\fscanffuns.c" />
+    <ClCompile Include="..\scanf\scanf.c" />
+    <ClCompile Include="..\scanf\sscanf.c" />
+    <ClCompile Include="..\scanf\sscanffuns.c" />
+    <ClCompile Include="..\scanf\vfscanf.c" />
+    <ClCompile Include="..\scanf\vscanf.c" />
+    <ClCompile Include="..\scanf\vsscanf.c" />
+    <ClCompile Include="..\tal-reent.c" />
+    <ClCompile Include="..\version.c" />
+    <ClCompile Include="mpn\andn_n.c" />
+    <ClCompile Include="mpn\and_n.c" />
+    <ClCompile Include="mpn\hamdist.c" />
+    <ClCompile Include="mpn\iorn_n.c" />
+    <ClCompile Include="mpn\ior_n.c" />
+    <ClCompile Include="mpn\nand_n.c" />
+    <ClCompile Include="mpn\nior_n.c" />
+    <ClCompile Include="mpn\popcount.c" />
+    <ClCompile Include="mpn\sec_add_1.c" />
+    <ClCompile Include="mpn\sec_div_qr.c" />
+    <ClCompile Include="mpn\sec_div_r.c" />
+    <ClCompile Include="mpn\sec_pi1_div_qr.c" />
+    <ClCompile Include="mpn\sec_pi1_div_r.c" />
+    <ClCompile Include="mpn\sec_sub_1.c" />
+    <ClCompile Include="mpn\xnor_n.c" />
+    <ClCompile Include="mpn\xor_n.c" />
+    <ClCompile Include="x86\mpn\fib_table.c">
+      <ExcludedFromBuild Condition="'$(Platform)'=='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="x86\mpn\mp_bases.c">
+      <ExcludedFromBuild Condition="'$(Platform)'=='x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="x86_64\mpn\fib_table.c">
+      <ExcludedFromBuild Condition="'$(Platform)'=='Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="x86_64\mpn\mp_bases.c">
+      <ExcludedFromBuild Condition="'$(Platform)'=='Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\mpf\fits_s.h" />
+    <ClInclude Include="..\mpf\fits_u.h" />
+    <ClInclude Include="..\mpn\generic\gmp-mparam.h" />
+    <ClInclude Include="..\mpz\aors.h" />
+    <ClInclude Include="..\mpz\aors_ui.h" />
+    <ClInclude Include="..\mpz\fits_s.h" />
+    <ClInclude Include="..\mpz\mul_i.h" />
+    <ClInclude Include="..\rand\randmt.h" />
+    <ClInclude Include="config.h" />
+    <ClInclude Include="gmp.h" />
+    <ClInclude Include="version.h" />
+    <ClInclude Include="x86\mpn\perfsqr.h" />
+    <ClInclude Include="x86_64\mpn\perfsqr.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{29DCC424-3CB3-4452-81A4-81A6A35127EC}</ProjectGuid>
+    <RootNamespace>libgmp-sandybridge</RootNamespace>
+    <ProjectName>libgmp-sandybridge</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '12.0'">v120</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>libgmpd</TargetName>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>libgmpd</TargetName>
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>gmpd</TargetName>
+    <LinkIncremental>false</LinkIncremental>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>gmpd</TargetName>
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <LinkIncremental>false</LinkIncremental>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>libgmp</TargetName>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|Win32'">
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>libgmp</TargetName>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>libgmp</TargetName>
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|x64'">
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>libgmp</TargetName>
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>gmp</TargetName>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">
+    <IntDir>$(SolutionDir)obj\$(Configuration)\$(Platform)\$(ProjectName)\</IntDir>
+    <TargetName>gmp</TargetName>
+    <OutDir>$(ProjectDir)..\..\..\msvc\</OutDir>
+    <CustomBuildAfterTargets>Clean</CustomBuildAfterTargets>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0502;_DEBUG;DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86;.\x86\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ProgramDataBaseFileName>$(OutDir)\lib\x86\$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)\lib\x86\$(TargetName)$(TargetExt)</OutputFile>
+      <TargetMachine>MachineX86</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+    </Lib>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0600;_DEBUG;DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86_64;.\x86_64\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ProgramDataBaseFileName>$(OutDir)\lib\x64\$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)\lib\x64\$(TargetName)$(TargetExt)</OutputFile>
+      <TargetMachine>MachineX64</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+    </Lib>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0502;DLL_EXPORT;_DEBUG;DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86;.\x86\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BufferSecurityCheck>true</BufferSecurityCheck>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <OutputFile>$(OutDir)\bin\x86\$(TargetName)$(TargetExt)</OutputFile>
+      <ProgramDatabaseFile>$(OutDir)\lib\x86\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <ImportLibrary>$(OutDir)\lib\x86\$(TargetName).lib</ImportLibrary>
+      <ProfileGuidedDatabase>$(IntDir)\$(TargetName).pgd</ProfileGuidedDatabase>
+      <ModuleDefinitionFile>
+      </ModuleDefinitionFile>
+      <LargeAddressAware>true</LargeAddressAware>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugDLL|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0600;DLL_EXPORT;_DEBUG;DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86_64;.\x86_64\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <OutputFile>$(OutDir)\bin\x64\$(TargetName)$(TargetExt)</OutputFile>
+      <ProgramDatabaseFile>$(OutDir)\lib\x64\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <ImportLibrary>$(OutDir)\lib\x64\$(TargetName).lib</ImportLibrary>
+      <ProfileGuidedDatabase>$(IntDir)\$(TargetName).pgd</ProfileGuidedDatabase>
+      <ModuleDefinitionFile>
+      </ModuleDefinitionFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0502;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86;.\x86\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <InterproceduralOptimization>SingleFile</InterproceduralOptimization>
+      <ProgramDataBaseFileName>$(OutDir)\lib\x86\$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)\lib\x86\$(TargetName)$(TargetExt)</OutputFile>
+      <TargetMachine>MachineX86</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+    </Lib>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0502;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86;.\x86\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <InterproceduralOptimization>SingleFile</InterproceduralOptimization>
+      <ProgramDataBaseFileName>$(OutDir)\lib\x86\$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)\lib\x86\$(TargetName)$(TargetExt)</OutputFile>
+      <TargetMachine>MachineX86</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+    </Lib>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0600;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86_64;.\x86_64\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <InterproceduralOptimization>SingleFile</InterproceduralOptimization>
+      <ProgramDataBaseFileName>$(OutDir)\lib\x64\$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)\lib\x64\$(TargetName)$(TargetExt)</OutputFile>
+      <TargetMachine>MachineX64</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+    </Lib>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLTO|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0600;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86_64;.\x86_64\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <InterproceduralOptimization>SingleFile</InterproceduralOptimization>
+      <ProgramDataBaseFileName>$(OutDir)\lib\x64\$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+    <Lib>
+      <OutputFile>$(OutDir)\lib\x64\$(TargetName)$(TargetExt)</OutputFile>
+      <TargetMachine>MachineX64</TargetMachine>
+      <SubSystem>Windows</SubSystem>
+    </Lib>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0502;DLL_EXPORT;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86;.\x86\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <OutputFile>$(OutDir)\bin\x86\$(TargetName)$(TargetExt)</OutputFile>
+      <ProgramDatabaseFile>$(OutDir)\lib\x86\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <ImportLibrary>$(OutDir)\lib\x86\$(TargetName).lib</ImportLibrary>
+      <ProfileGuidedDatabase>$(IntDir)\$(TargetName).pgd</ProfileGuidedDatabase>
+      <ModuleDefinitionFile>
+      </ModuleDefinitionFile>
+      <LargeAddressAware>true</LargeAddressAware>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseDLL|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <OmitFramePointers>true</OmitFramePointers>
+      <StringPooling>true</StringPooling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <FloatingPointExceptions>false</FloatingPointExceptions>
+      <PreprocessorDefinitions>inline=__inline;__GMP_WITHIN_GMP;NO_ASM;HAVE_CONFIG_H;_WIN32_WINNT=0x0600;DLL_EXPORT;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\;..\;.\mpn;.\x86_64;.\x86_64\mpn;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>false</ExceptionHandling>
+      <DisableSpecificWarnings>4996;4244;4146;4018;4554;4090;4267;4101;4334;4723;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ProgramDataBaseFileName>$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <OutputFile>$(OutDir)\bin\x64\$(TargetName)$(TargetExt)</OutputFile>
+      <ProgramDatabaseFile>$(OutDir)\lib\x64\$(TargetName).pdb</ProgramDatabaseFile>
+      <SubSystem>Windows</SubSystem>
+      <ImportLibrary>$(OutDir)\lib\x64\$(TargetName).lib</ImportLibrary>
+      <ProfileGuidedDatabase>$(IntDir)\$(TargetName).pgd</ProfileGuidedDatabase>
+      <ModuleDefinitionFile>
+      </ModuleDefinitionFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <PostBuildEvent>
+      <Command>mkdir $(OutDir)\include
+copy .\gmp.h $(OutDir)\include\
+mkdir $(OutDir)\licenses
+copy ..\COPYING.LESSERv3 $(OutDir)\licenses\gmp.txt</Command>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>if exist ..\config.h (
+del ..\config.h
+)
+if exist $(OutDir)\include\gmp.h (
+del $(OutDir)\include\gmp.h
+)
+if exist ..\fac_table.h (
+del ..\fac_table.h
+)
+if exist ..\fib_table.h (
+del ..\fib_table.h
+)
+if exist ..\gmp.h (
+del ..\gmp.h
+)
+if exist ..\mp_bases.h (
+del ..\mp_bases.h
+)
+if exist ..\trialdivtab.h (
+del ..\trialdivtab.h
+)
+if exist ..\mpn\perfsqr.h (
+del ..\mpn\perfsqr.h
+)
+if exist ..\mpn\jacobitab.h (
+del ..\mpn\jacobitab.h
+)
+if exist ..\mpn\mp_bases.c (
+del ..\mpn\mp_bases.c
+)
+if exist ..\mpn\fib_table.c (
+del ..\mpn\fib_table.c
+)
+if exist ..\gmp-mparam.h (
+del ..\gmp-mparam.h
+)
+if not exist .\gmp-mparam.h (
+copy ..\mpn\generic\gmp-mparam.h .\gmp-mparam.h
+)</Command>
+    </PreBuildEvent>
+    <CustomBuildStep>
+      <Message>Custom Clean Step</Message>
+    </CustomBuildStep>
+    <CustomBuildStep>
+      <Outputs>force_clean</Outputs>
+      <Command>if exist $(OutDir)\include\gmp.h (
+del /f /q $(OutDir)\include\gmp.h
+)
+if exist $(OutDir)\licenses\gmp.txt (
+del /f /q $(OutDir)\licenses\gmp.txt
+)</Command>
+    </CustomBuildStep>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/SMP/libgmp-sandybridge.vcxproj.filters
+++ b/SMP/libgmp-sandybridge.vcxproj.filters
@@ -1,0 +1,1638 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{e850f24d-093f-4c30-a99c-413a7dfa71b8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{f18cd969-acc3-480c-9147-ea3ae1c8ba92}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{bdd0568e-d423-4fcc-affe-6ba0c2a40f78}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\mpf">
+      <UniqueIdentifier>{8b05f417-d919-4ea6-931f-3262aa26697b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\mpf">
+      <UniqueIdentifier>{2634c01a-3223-4391-ae7e-9548ff10e9da}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\mpq">
+      <UniqueIdentifier>{ed9663a9-86f2-46d7-a35f-f3e138e7c9a2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\mpz">
+      <UniqueIdentifier>{553b1a88-7119-40a5-9d85-7dbfaf80ba78}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\mpz">
+      <UniqueIdentifier>{0fac6710-a7c5-4cf3-8652-00499b5c1320}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\printf">
+      <UniqueIdentifier>{2d6ee7be-e02a-4d3b-99ca-2e53e34317e1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\rand">
+      <UniqueIdentifier>{55e7bf08-a88a-43e3-822a-a82854b91482}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\rand">
+      <UniqueIdentifier>{4ba57ad3-b559-4b01-bd74-f86543e84f68}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\scanf">
+      <UniqueIdentifier>{436933a6-59c0-443b-a260-302e90a72512}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\mpn">
+      <UniqueIdentifier>{74d58b68-dc90-45b5-a87f-a0f34193854d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\mpn">
+      <UniqueIdentifier>{cfae7b2c-37c2-4d27-87fa-129ec5789a6c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\mpn\generic">
+      <UniqueIdentifier>{2f480092-cafb-4eba-95f5-8e9bed93331e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\mpn\generic">
+      <UniqueIdentifier>{ca8332c9-161a-4054-8687-c4ece8d8daca}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\mpn\x86">
+      <UniqueIdentifier>{d8815d62-b0e7-40a5-b5e7-50a32297b021}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\mpn\x86_64">
+      <UniqueIdentifier>{55fc46ef-b616-4264-99fb-46d34c4e4e2a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\mpn\x86">
+      <UniqueIdentifier>{31695252-6539-475f-aa56-81ec7bc27230}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\mpn\x86_64">
+      <UniqueIdentifier>{97b7147a-9665-4a85-b688-69fc54cc9f64}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\mpf\fits_sint.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_slong.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_sshort.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_uint.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_ulong.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\fits_ushort.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_d.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_d_2exp.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_dfl_prec.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_prc.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_si.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_str.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\get_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\init.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\init2.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\inits.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\inp_str.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\int_p.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_d.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_si.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_str.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\iset_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\mul.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\mul_2exp.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\mul_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\neg.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\out_str.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\pow_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\random2.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\reldiff.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_d.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_dfl_prec.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_prc.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_prc_raw.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_q.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_si.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_str.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\set_z.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\size.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sqrt.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sqrt_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sub.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\sub_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\swap.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\trunc.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\ui_div.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\ui_sub.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\urandomb.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\abs.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\add.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\add_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\ceilfloor.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\clear.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\clears.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_d.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_si.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\div.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\div_2exp.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\div_ui.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\dump.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\eq.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\equal.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\get_d.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\get_den.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\get_num.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\get_str.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\init.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\inits.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\inp_str.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\inv.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\md_2exp.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\mul.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\neg.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\out_str.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_d.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_den.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_f.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_num.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_si.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_str.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_ui.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\set_z.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\swap.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\abs.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\aors.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\canonicalize.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\clear.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\clears.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\cmp.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\cmp_si.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\cmp_ui.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpq\div.c">
+      <Filter>Source Files\mpq</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_str.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\setbit.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\size.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sizeinbase.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sqrt.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sqrtrem.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sub.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\sub_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\swap.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_q.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_q_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_q_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_qr.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_qr_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_r.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_r_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_r_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tdiv_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\tstbit.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\ui_pow_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\ui_sub.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\urandomb.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\urandomm.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\xor.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\2fac_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\abs.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\add.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\add_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\and.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\aorsmul.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\aorsmul_i.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\array_init.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\bin_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\bin_uiui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cdiv_q.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cdiv_q_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cdiv_qr.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cdiv_qr_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cdiv_r.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cdiv_r_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cdiv_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cfdiv_q_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cfdiv_r_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\clear.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\clears.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\clrbit.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmp_d.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmp_si.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmp_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmpabs.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmpabs_d.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cmpabs_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\com.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\combit.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cong.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cong_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\cong_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\dive_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\divegcd.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\divexact.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\divis.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\divis_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\divis_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\dump.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\export.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fac_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fdiv_q.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fdiv_q_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fdiv_qr.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fdiv_qr_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fdiv_r.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fdiv_r_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fdiv_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fib_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fib2_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_sint.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_slong.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_sshort.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_uint.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_ulong.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\fits_ushort.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\gcd.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\gcd_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\gcdext.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_d.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_d_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_si.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_str.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\get_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\getlimbn.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\hamdist.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\import.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\init.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\init2.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\inits.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\inp_raw.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\inp_str.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\invert.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\ior.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_d.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_si.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_str.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\iset_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\jacobi.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\kronsz.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\kronuz.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\kronzs.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\kronzu.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\lcm.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\lcm_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\limbs_finish.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\limbs_modify.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\limbs_read.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\limbs_write.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\lucnum_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\lucnum2_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mfac_uiui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\millerrabin.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mod.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mul.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mul_2exp.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mul_si.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\mul_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\n_pow_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\neg.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\nextprime.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\oddfac_1.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\out_raw.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\out_str.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\perfpow.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\perfsqr.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\popcount.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\pow_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\powm.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\powm_sec.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\powm_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\pprime_p.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\primorial_ui.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\prodlimbs.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\random.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\random2.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\realloc.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\realloc2.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\remove.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\roinit_n.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\root.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\rootrem.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\rrandomb.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\scan0.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\scan1.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_d.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_f.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_q.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpz\set_si.c">
+      <Filter>Source Files\mpz</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\printf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\printffuns.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\repl-vsnprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\snprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\snprntffuns.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\sprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\sprintffuns.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\vasprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\vfprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\vprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\vsnprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\vsprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\asprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\asprntffuns.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\doprnt.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\doprntf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\doprnti.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\fprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\obprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\obprntffuns.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\printf\obvprintf.c">
+      <Filter>Source Files\printf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randlc2x.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randmt.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randmts.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randmui.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\rands.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randsd.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randsdui.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\rand.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randbui.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randclr.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randdef.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randiset.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rand\randlc2s.c">
+      <Filter>Source Files\rand</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\sscanffuns.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\vfscanf.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\vscanf.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\vsscanf.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\doscan.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\fscanf.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\fscanffuns.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\scanf.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scanf\sscanf.c">
+      <Filter>Source Files\scanf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tal-reent.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\version.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\assert.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\compat.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\errno.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\extract-dbl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\invalid.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\memory.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mp_bpl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mp_clz_tab.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mp_dv_tab.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mp_get_fns.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mp_minv_tab.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mp_set_fns.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\nextprime.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\primesieve.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom3_sqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom4_sqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom6_sqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom6h_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom8_sqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom8h_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom22_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom32_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom33_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom42_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom42_mulmid.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom43_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom44_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom52_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom53_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom54_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom62_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom63_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\trialdiv.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\zero.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add_err1_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add_err2_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add_err3_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\add_n_sub_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\addmul_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\bdiv_dbm1c.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\bdiv_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\bdiv_q_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\bdiv_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\binvert.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\broot.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\brootinv.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\bsqrt.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\bsqrtinv.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\cmp.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\cnd_add_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\cnd_sub_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\com.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\comb_tables.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\copyd.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\copyi.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\dcpi1_bdiv_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\dcpi1_bdiv_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\dcpi1_div_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\dcpi1_div_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\dcpi1_divappr_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_qr_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_qr_1n_pi1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_qr_1n_pi2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_qr_1u_pi2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_qr_2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_qr_2n_pi1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\div_qr_2u_pi1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\dive_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\diveby3.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\divexact.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\divis.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\divrem.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\divrem_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\divrem_2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\dump.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\fib2_ui.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\gcd.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\gcd_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\gcd_subdiv_step.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\gcdext.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\gcdext_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\gcdext_lehmer.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\get_d.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\get_str.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd_appr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd_jacobi.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd_matrix.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd_reduce.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd_step.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\hgcd2_jacobi.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\invert.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\invertappr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\jacbase.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\jacobi.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\jacobi_2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\lshift.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\lshiftc.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\matrix22_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\matrix22_mul1_inverse_vector.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mod_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mod_1_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mod_1_2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mod_1_3.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mod_1_4.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mod_34lsub1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mode1o.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mu_bdiv_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mu_bdiv_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mu_div_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mu_div_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mu_divappr_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mul_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mul_basecase.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mul_fft.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mul_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mullo_basecase.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mullo_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mulmid.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mulmid_basecase.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mulmid_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mulmod_bnm1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\neg.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\nussbaumer_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\perfpow.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\perfsqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\pow_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\powlo.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\powm.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\pre_divrem_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\pre_mod_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\random.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\random2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\redc_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\redc_2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\redc_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\remove.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\rootrem.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\rshift.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sbpi1_bdiv_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sbpi1_bdiv_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sbpi1_div_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sbpi1_div_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sbpi1_divappr_q.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\scan0.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\scan1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sec_invert.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sec_mul.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sec_powm.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sec_sqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sec_tabselect.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\set_str.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sizeinbase.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sqr_basecase.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sqrmod_bnm1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sqrtrem.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sub.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sub_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sub_err1_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sub_err2_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sub_err3_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sub_n.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\submul_1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\tdiv_qr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_couple_handling.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_eval_dgr3_pm1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_eval_dgr3_pm2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_eval_pm1.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_eval_pm2.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_eval_pm2exp.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_eval_pm2rexp.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_interpolate_5pts.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_interpolate_6pts.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_interpolate_7pts.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_interpolate_8pts.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_interpolate_12pts.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom_interpolate_16pts.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\toom2_sqr.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\iorn_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\nand_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\nior_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\popcount.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\sec_add_1.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\sec_div_qr.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\sec_div_r.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\sec_pi1_div_qr.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\sec_pi1_div_r.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\sec_sub_1.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\xnor_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\xor_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\and_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\andn_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\hamdist.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="mpn\ior_n.c">
+      <Filter>Source Files\mpn</Filter>
+    </ClCompile>
+    <ClCompile Include="x86\mpn\mp_bases.c">
+      <Filter>Source Files\mpn\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="x86\mpn\fib_table.c">
+      <Filter>Source Files\mpn\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="x86_64\mpn\mp_bases.c">
+      <Filter>Source Files\mpn\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="x86_64\mpn\fib_table.c">
+      <Filter>Source Files\mpn\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpf\cmp_z.c">
+      <Filter>Source Files\mpf</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sqrlo_basecase.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\sqrlo.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\cnd_swap.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\mpf\fits_s.h">
+      <Filter>Header Files\mpf</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mpf\fits_u.h">
+      <Filter>Header Files\mpf</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mpz\aors.h">
+      <Filter>Header Files\mpz</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mpz\aors_ui.h">
+      <Filter>Header Files\mpz</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mpz\fits_s.h">
+      <Filter>Header Files\mpz</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mpz\mul_i.h">
+      <Filter>Header Files\mpz</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rand\randmt.h">
+      <Filter>Header Files\rand</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mpn\generic\gmp-mparam.h">
+      <Filter>Header Files\mpn\generic</Filter>
+    </ClInclude>
+    <ClInclude Include="config.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="gmp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="x86\mpn\perfsqr.h">
+      <Filter>Header Files\mpn\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="x86_64\mpn\perfsqr.h">
+      <Filter>Header Files\mpn\x86_64</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/SMP/libgmp-sandybridge.vcxproj.filters
+++ b/SMP/libgmp-sandybridge.vcxproj.filters
@@ -61,6 +61,9 @@
     <Filter Include="Header Files\mpn\x86_64">
       <UniqueIdentifier>{97b7147a-9665-4a85-b688-69fc54cc9f64}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\mpn\yasm">
+      <UniqueIdentifier>{6963dad3-631a-4444-88f8-ac9e2af775d7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\mpf\fits_sint.c">
@@ -969,9 +972,6 @@
     <ClCompile Include="..\assert.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\compat.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\errno.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -1074,22 +1074,10 @@
     <ClCompile Include="..\mpn\generic\add_1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\add_err1_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\add_err2_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\add_err3_n.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\add_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\add_n_sub_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\addmul_1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\bdiv_dbm1c.c">
@@ -1134,12 +1122,6 @@
     <ClCompile Include="..\mpn\generic\comb_tables.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\copyd.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\copyi.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\dcpi1_bdiv_q.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
@@ -1179,12 +1161,6 @@
     <ClCompile Include="..\mpn\generic\div_qr_2u_pi1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\dive_1.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\diveby3.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\divexact.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
@@ -1195,9 +1171,6 @@
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\divrem_1.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\divrem_2.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\dump.c">
@@ -1269,12 +1242,6 @@
     <ClCompile Include="..\mpn\generic\jacobi_2.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\lshift.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\lshiftc.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\matrix22_mul.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
@@ -1284,22 +1251,10 @@
     <ClCompile Include="..\mpn\generic\mod_1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\mod_1_1.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\mod_1_2.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\mod_1_3.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\mod_1_4.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\mod_34lsub1.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\mode1o.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\mu_bdiv_q.c">
@@ -1320,12 +1275,6 @@
     <ClCompile Include="..\mpn\generic\mul.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\mul_1.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\mul_basecase.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\mul_fft.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
@@ -1339,9 +1288,6 @@
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\mulmid.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\mulmid_basecase.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\mulmid_n.c">
@@ -1371,9 +1317,6 @@
     <ClCompile Include="..\mpn\generic\powm.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\pre_divrem_1.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\pre_mod_1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
@@ -1381,9 +1324,6 @@
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\random2.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\redc_1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\redc_2.c">
@@ -1396,9 +1336,6 @@
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\rootrem.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\rshift.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\sbpi1_bdiv_q.c">
@@ -1446,9 +1383,6 @@
     <ClCompile Include="..\mpn\generic\sqr.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\sqr_basecase.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\sqrmod_bnm1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
@@ -1461,19 +1395,7 @@
     <ClCompile Include="..\mpn\generic\sub_1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="..\mpn\generic\sub_err1_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\sub_err2_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
     <ClCompile Include="..\mpn\generic\sub_err3_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\sub_n.c">
-      <Filter>Source Files\mpn\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\mpn\generic\submul_1.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\tdiv_qr.c">
@@ -1521,18 +1443,6 @@
     <ClCompile Include="..\mpn\generic\toom2_sqr.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
-    <ClCompile Include="mpn\iorn_n.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\nand_n.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\nior_n.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\popcount.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
     <ClCompile Include="mpn\sec_add_1.c">
       <Filter>Source Files\mpn</Filter>
     </ClCompile>
@@ -1549,24 +1459,6 @@
       <Filter>Source Files\mpn</Filter>
     </ClCompile>
     <ClCompile Include="mpn\sec_sub_1.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\xnor_n.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\xor_n.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\and_n.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\andn_n.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\hamdist.c">
-      <Filter>Source Files\mpn</Filter>
-    </ClCompile>
-    <ClCompile Include="mpn\ior_n.c">
       <Filter>Source Files\mpn</Filter>
     </ClCompile>
     <ClCompile Include="x86\mpn\mp_bases.c">
@@ -1591,6 +1483,9 @@
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
     <ClCompile Include="..\mpn\generic\cnd_swap.c">
+      <Filter>Source Files\mpn\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mpn\generic\mul_basecase.c">
       <Filter>Source Files\mpn\generic</Filter>
     </ClCompile>
   </ItemGroup>
@@ -1634,5 +1529,163 @@
     <ClInclude Include="x86_64\mpn\perfsqr.h">
       <Filter>Header Files\mpn\x86_64</Filter>
     </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <YASM Include="yasm\add_err1_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\add_err2_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\addmul_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\divexact_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\divexact_by3c.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\divexact_byfobm1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\divrem_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\divrem_euclidean_qr_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\divrem_euclidean_qr_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\modexact_1c_odd.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\mul_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\mulmid_basecase.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sqr_basecase.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sub_err1_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sub_err2_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\udiv_qrnnd.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\umul_ppmm.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\add_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\addmul_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\addmul_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\and_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\andn_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\com_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\copyd.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\copyi.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\divexact_byff.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\divrem_hensel_qr_1_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\hamdist.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\ior_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\iorn_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\karaadd.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\karasub.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\lshift.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\lshift1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\lshiftc.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mod_1_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mod_1_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mod_1_3.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mul_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\mul_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\nand_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\nior_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\popcount.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\redc_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\rsh_divrem_hensel_qr_1_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\rsh_divrem_hensel_qr_1_2.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\rshift.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\store.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\sub_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\submul_1.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\xnor_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
+    <YASM Include="yasm\sandybridge\xor_n.asm">
+      <Filter>Source Files\mpn\yasm</Filter>
+    </YASM>
   </ItemGroup>
 </Project>

--- a/SMP/libgmp-sandybridge.vcxproj.filters
+++ b/SMP/libgmp-sandybridge.vcxproj.filters
@@ -1537,9 +1537,6 @@
     <YASM Include="yasm\add_err2_n.asm">
       <Filter>Source Files\mpn\yasm</Filter>
     </YASM>
-    <YASM Include="yasm\addmul_2.asm">
-      <Filter>Source Files\mpn\yasm</Filter>
-    </YASM>
     <YASM Include="yasm\divexact_1.asm">
       <Filter>Source Files\mpn\yasm</Filter>
     </YASM>
@@ -1559,9 +1556,6 @@
       <Filter>Source Files\mpn\yasm</Filter>
     </YASM>
     <YASM Include="yasm\modexact_1c_odd.asm">
-      <Filter>Source Files\mpn\yasm</Filter>
-    </YASM>
-    <YASM Include="yasm\mul_2.asm">
       <Filter>Source Files\mpn\yasm</Filter>
     </YASM>
     <YASM Include="yasm\mulmid_basecase.asm">

--- a/SMP/libgmp.sln
+++ b/SMP/libgmp.sln
@@ -1,6 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libgmp", "libgmp.vcxproj", "{02B94302-23D6-43EF-8865-95CDE99D5DC2}"
 EndProject
@@ -17,6 +18,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gen-fib", "gen-fib.vcxproj", "{D64CDBFD-FAF5-4AB2-9A7A-3CFAF86A0354}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gen-fac", "gen-fac.vcxproj", "{51EF8902-63B3-4579-B816-B4DC3A2789ED}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libgmp-sandybridge", "libgmp-sandybridge.vcxproj", "{29DCC424-3CB3-4452-81A4-81A6A35127EC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -112,6 +115,26 @@ Global
 		{51EF8902-63B3-4579-B816-B4DC3A2789ED}.ReleaseDLL|x86.ActiveCfg = Release|Win32
 		{51EF8902-63B3-4579-B816-B4DC3A2789ED}.ReleaseLTO|x64.ActiveCfg = Release|x64
 		{51EF8902-63B3-4579-B816-B4DC3A2789ED}.ReleaseLTO|x86.ActiveCfg = Release|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Debug|x64.ActiveCfg = Debug|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Debug|x64.Build.0 = Debug|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Debug|x86.ActiveCfg = Debug|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Debug|x86.Build.0 = Debug|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.DebugDLL|x64.ActiveCfg = Debug|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.DebugDLL|x64.Build.0 = Debug|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.DebugDLL|x86.ActiveCfg = Debug|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.DebugDLL|x86.Build.0 = Debug|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Release|x64.ActiveCfg = Release|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Release|x64.Build.0 = Release|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Release|x86.ActiveCfg = Release|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.Release|x86.Build.0 = Release|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseDLL|x64.ActiveCfg = Release|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseDLL|x64.Build.0 = Release|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseDLL|x86.ActiveCfg = Release|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseDLL|x86.Build.0 = Release|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseLTO|x64.ActiveCfg = Release|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseLTO|x64.Build.0 = Release|x64
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseLTO|x86.ActiveCfg = Release|Win32
+		{29DCC424-3CB3-4452-81A4-81A6A35127EC}.ReleaseLTO|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SMP/pi.vcxproj
+++ b/SMP/pi.vcxproj
@@ -1,0 +1,162 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>pi</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>.;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <LibraryPath>..\..\..\msvc\lib\$(Platform);$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>.;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <LibraryPath>..\..\..\msvc\lib\$(Platform);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>.;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <LibraryPath>..\..\..\msvc\lib\$(Platform);$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>.;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <LibraryPath>..\..\..\msvc\lib\$(Platform);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgmp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgmp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgmp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgmp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\gmp-chudnovsky.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/SMP/pi.vcxproj.filters
+++ b/SMP/pi.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\gmp-chudnovsky.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/SMP/tests.sln
+++ b/SMP/tests.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pi", "pi.vcxproj", "{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Debug|x64.ActiveCfg = Debug|x64
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Debug|x64.Build.0 = Debug|x64
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Debug|x86.ActiveCfg = Debug|Win32
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Debug|x86.Build.0 = Debug|Win32
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Release|x64.ActiveCfg = Release|x64
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Release|x64.Build.0 = Release|x64
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Release|x86.ActiveCfg = Release|Win32
+		{9D4138DF-FF5E-4297-AF4C-C4F1E3E5F099}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/SMP/yasm/add_err1_n.asm
+++ b/SMP/yasm/add_err1_n.asm
@@ -1,0 +1,104 @@
+; PROLOGUE(mpn_add_err1_n)
+
+;  Copyright (C) 2009, David Harvey
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  All rights reserved.
+;
+;  Redistribution and use in source and binary forms, with or without
+;  modification, are permitted provided that the following conditions are
+;  met:
+;  1. Redistributions of source code must retain the above copyright notice,
+;  this list of conditions and the following disclaimer.
+;
+;  2. Redistributions in binary form must reproduce the above copyright
+;  notice, this list of conditions and the following disclaimer in the
+;  documentation and/or other materials provided with the distribution.
+;
+;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+;  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;  HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+;  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+;  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;
+;  mp_limb_t mpn_add_err1_n(mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  mp_limb_t mpn_sub_err1_n(mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  rax                         rdi     rsi     rdx     rcx       r8        r9     8(rsp)
+;  rax                         rcx     rdx      r8      r9 [rsp+40]  [rsp+48]   [rsp+56]
+
+%include "yasm_mac.inc"
+
+%define reg_save_list   rbx, rsi, rdi, rbp, r12
+
+%macro fun 2
+	xalign  16
+    FRAME_PROC %1, 0, reg_save_list
+    mov     rax, qword [rsp+stack_use+48]
+    lea     rdi, [rcx+rax*8]
+    lea     rsi, [rdx+rax*8]
+    lea     rdx, [r8+rax*8]
+    mov     rcx, r9
+    mov     r9, rax
+    mov     r8, [rsp+stack_use+40]
+    mov     rax, [rsp+stack_use+56]
+    
+	xor     rbx, rbx
+	xor     rbp, rbp
+	test    r9, 1
+	jnz     %%2
+%%1:lea     r8, [r8+r9*8-8]
+	neg     r9
+	jmp     %%3
+
+	xalign  16
+%%2:lea     r8, [r8+r9*8-16]
+	neg     r9
+	shr     rax, 1
+	mov     r12, [rsi+r9*8]
+	%2      r12, [rdx+r9*8]
+	cmovc   rbx, [r8+8]
+	mov     [rdi+r9*8], r12
+	setc    al
+	inc     r9
+	jz      %%4
+
+	xalign  16
+%%3:mov     r12, [rsi+r9*8]
+	shr     rax, 1
+	%2      r12, [rdx+r9*8]
+	mov     r11, 0
+	mov     [rdi+r9*8], r12
+	mov     r10, 0
+	mov     r12, [rsi+r9*8+8]
+	cmovc   r10, [r8]
+	%2      r12, [rdx+r9*8+8]
+	cmovc   r11, [r8-8]
+	setc    al
+	add     rbx, r10
+	adc     rbp, 0
+	add     rbx, r11
+	mov     [rdi+r9*8+8], r12
+	adc     rbp, 0
+	add     r9, 2
+	lea     r8, [r8-16]
+	jnz     %%3
+%%4:mov     [rcx], rbx
+	mov     [rcx+8], rbp
+    END_PROC reg_save_list
+%endmacro
+
+
+    CPU  Athlon64
+    BITS 64
+;   global __gmpn_add_err1_n
+
+    fun mpn_add_err1_n, adc
+    
+    end

--- a/SMP/yasm/add_err2_n.asm
+++ b/SMP/yasm/add_err2_n.asm
@@ -1,0 +1,122 @@
+; PROLOGUE(mpn_add_err2_n)
+;
+;  AMD64 mpn_add_err2_n, mpn_sub_err2_n
+;
+;  Copyright (C) 2009, David Harvey
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  All rights reserved.
+;
+;  Redistribution and use in source and binary forms, with or without
+;  modification, are permitted provided that the following conditions are
+;  met:
+;
+;  1. Redistributions of source code must retain the above copyright notice,
+;  this list of conditions and the following disclaimer.
+;
+;  2. Redistributions in binary form must reproduce the above copyright
+;  notice, this list of conditions and the following disclaimer in the
+;  documentation and/or other materials provided with the distribution.
+;
+;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+;  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;  HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+;  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+;  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;
+;  mp_limb_t mpn_add_err2_n (mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr,  mp_ptr, mp_size_t, mp_limb_t);
+;  mp_limb_t mpn_sub_err2_n (mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr,  mp_ptr, mp_size_t, mp_limb_t);
+;  rax                          rdi     rsi     rdx     rcx       r8      r9     8(rsp)    16(rsp)
+;  rax                          rcx     rdx      r8      r9 [rsp+40] [rsp+48]  [rsp+56]   [rsp+64]
+
+%include "yasm_mac.inc"
+
+%define reg_save_list   rbx, rsi, rdi, rbp, r12, r13, r14
+
+%macro fun 2
+	xalign  16
+    FRAME_PROC %1, 0, reg_save_list
+    mov     rax, qword [rsp+stack_use+56]
+    lea     rdi, [rcx+rax*8]
+    lea     rsi, [rdx+rax*8]
+    lea     rdx, [r8+rax*8]
+    mov     rcx, r9
+    mov     r10, rax
+    mov     r8, [rsp+stack_use+40]
+    mov     r9, [rsp+stack_use+48]
+    mov     rax, [rsp+stack_use+64]
+    
+	xor     rbp, rbp
+	xor     r11, r11
+	xor     r12, r12
+	xor     r13, r13
+	sub     r9, r8
+	test    r10, 1
+	jnz     %%1
+	lea     r8, [r8+r10*8-8]
+	neg     r10
+	jmp     %%2
+
+	xalign  16
+%%1:lea     r8, [r8+r10*8-16]
+	neg     r10
+	shr     rax, 1
+	mov     rbx, [rsi+r10*8]
+	%2      rbx, [rdx+r10*8]
+	cmovc   rbp, [r8+8]
+	cmovc   r12, [r8+r9+8]
+	mov     [rdi+r10*8], rbx
+	sbb     rax, rax
+	inc     r10
+	jz      %%3
+
+	xalign  16
+%%2:mov     rbx, [rsi+r10*8]
+	shr     rax, 1
+	%2      rbx, [rdx+r10*8]
+	mov     [rdi+r10*8], rbx
+	sbb     r14, r14
+	mov     rbx, [rsi+r10*8+8]
+	%2      rbx, [rdx+r10*8+8]
+	mov     [rdi+r10*8+8], rbx
+	sbb     rax, rax
+    mov     rbx, [r8]
+	and     rbx, r14
+	add     rbp, rbx
+	adc     r11, 0
+    and     r14, [r8+r9]
+	add     r12, r14
+	adc     r13, 0
+    mov     rbx, [r8-8]
+	and     rbx, rax
+	add     rbp, rbx
+	adc     r11, 0
+    mov     rbx, [r8+r9-8]
+	and     rbx, rax
+	add     r12, rbx
+	adc     r13, 0
+	add     r10, 2
+	lea     r8, [r8-16]
+	jnz     %%2
+%%3:mov     [rcx], rbp
+	mov     [rcx+8], r11
+	mov     [rcx+16], r12
+	mov     [rcx+24], r13
+	and     eax, 1
+    END_PROC reg_save_list
+%endmacro
+
+    CPU  Athlon64
+    BITS 64
+;		global __gmpn_add_err2_n
+
+    fun mpn_add_err2_n, adc
+    
+    end

--- a/SMP/yasm/addmul_2.asm
+++ b/SMP/yasm/addmul_2.asm
@@ -1,0 +1,207 @@
+; PROLOGUE(mpn_addmul_2)
+
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_addmul_2(mp_ptr, mp_ptr, mp_size_t, mp_ptr)
+;  rax                       rdi     rsi        rdx     rcx
+;  rax                       rcx     rdx         r8      r9
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rbx, rsi, rdi, r12
+
+	FRAME_PROC mpn_addmul_2, 0, reg_save_list
+	mov     rdi, rcx
+	mov     rsi, rdx
+	mov     rax, r8
+	
+	mov     rcx, [r9]
+	mov     r8, [r9+8]
+	mov     rbx, 4
+	sub     rbx, rax
+	lea     rsi, [rsi+rax*8-32]
+	lea     rdi, [rdi+rax*8-32]
+	mov     r10, 0
+	mov     rax, [rsi+rbx*8]
+	mul     rcx
+	mov     r12, rax
+	mov     r9, rdx
+	cmp     rbx, 0
+	jge     .2
+	
+	xalign  16
+.1: mov     rax, [rsi+rbx*8]
+	mul     r8
+	add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     rcx
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	adc     r12, 0
+	mul     r8
+	add     [rdi+rbx*8+16], r10
+	mov     r9, 0
+	adc     r11, rax
+	mov     r10, 0
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	mov     r15, r15
+	mul     rcx
+	add     r11, rax
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	adc     r9, 0
+	mul     r8
+	add     [rdi+rbx*8+24], r11
+	adc     r12, rax
+	adc     r9, rdx
+	mov     rax, [rsi+rbx*8+32]
+	mul     rcx
+	add     r12, rax
+	adc     r9, rdx
+	adc     r10, 0
+	add     rbx, 4
+	jnc     .1
+.2:	mov     rax, [rsi+rbx*8]
+	mul     r8
+	cmp     rbx, 2
+	ja      .6
+	jz      .5
+	jp      .4
+.3: add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     rcx
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	adc     r12, 0
+	mul     r8
+	add     [rdi+rbx*8+16], r10
+	mov     r9, 0
+	adc     r11, rax
+	; padding
+	mov     r10, 0
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	; padding
+	mov     r15, r15
+	mul     rcx
+	add     r11, rax
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	adc     r9, 0
+	mul     r8
+	add     [rdi+rbx*8+24], r11
+	adc     r12, rax
+	adc     r9, rdx
+	mov     [rdi+rbx*8+32], r12
+	mov     rax, r9
+	jmp     .7
+
+	xalign  16
+.4: add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     rcx
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	adc     r12, 0
+	mul     r8
+	add     [rdi+rbx*8+16], r10
+	adc     r11, rax
+	adc     r12, rdx
+	mov     [rdi+rbx*8+24], r11
+	mov     rax, r12
+    EXIT_PROC reg_save_list
+	
+	xalign  16
+.5: add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     [rdi+rbx*8+16], r10
+	mov     rax, r11
+    EXIT_PROC reg_save_list
+
+	xalign  16
+.6: add     [rdi+rbx*8], r12
+	adc     r9, rax
+	adc     r10, rdx
+	mov     [rdi+rbx*8+8], r9
+	mov     rax, r10
+.7:	END_PROC reg_save_list
+
+    end

--- a/SMP/yasm/divexact_1.asm
+++ b/SMP/yasm/divexact_1.asm
@@ -1,0 +1,134 @@
+; PROLOGUE(mpn_divexact_1)
+
+;  Copyright 1999, 2000, 2001, 2002 Free Software Foundation, Inc.
+;
+;  Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or
+;  modify it under the terms of the GNU Lesser General Public License as
+;  published by the Free Software Foundation; either version 2.1 of the
+;  License, or (at your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;  Lesser General Public License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public
+;  License along with the MPIR Library; see the file COPYING.LIB.  If
+;  not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+;  Fifth Floor, Boston, MA 02110-1301, USA.
+;
+; since the inverse takes a while to setup,plain division is used for small
+; Multiplying works out faster for size>=3 when the divisor is odd or size>=4
+; when the divisor is even.
+;
+;  void mpn_divexact_1(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;                         rdi     rsi        rdx        rcx
+;                         rcx     rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+%define reg_save_list       rsi, rdi
+
+    BITS 64
+
+    extern  __gmp_binvert_limb_table
+
+    LEAF_PROC mpn_divexact_1
+    mov     r10, rdx
+    mov     rax, r9
+    and     rax, byte 1
+    add     rax, r8
+    cmp     rax, byte 4
+    jae     .2
+    xor     rdx,rdx
+.1: mov     rax, [r10+r8*8-8]
+    div     r9
+    mov     [rcx+r8*8-8], rax
+    sub     r8, 1
+    jnz     .1
+    ret                     ; avoid single byte return
+
+.2:	FRAME_PROC ?mpn_divexact, 0, reg_save_list
+    mov     rsi, rdx        ; src pointer
+    mov     rdi, rcx        ; dst pointer
+    bsf     rcx, r9         ; remove powers of two
+    shr     r9, cl
+    mov     rax, r9
+    shr     rax, 1
+    and     rax, 127
+    lea     rdx, [rel __gmp_binvert_limb_table]
+    movzx   rax, byte [rdx+rax]
+
+; If f(x) = 0, then x[n+1] = x[n] - f(x) / f'(x) is Newton's iteration for a
+; root. With f(x) = 1/x - v we obtain x[n + 1] = 2 * x[n] - v * x[n] * x[n]
+; as an iteration for x = 1 / v.  This provides quadratic convergence so
+; that the number of bits of precision doubles on each iteration.  The
+; iteration starts with 8-bit precision.
+
+    lea     edx, [rax+rax]
+    imul    eax, eax
+    imul    eax, r9d
+    sub     edx, eax            ; inv -> rdx (16-bit approx)
+
+    lea     eax, [rdx+rdx]
+    imul    edx, edx
+    imul    edx, r9d
+    sub     eax, edx            ; inv -> rdx (32-bit approx)
+
+    lea     rdx, [rax+rax]
+    imul    rax, rax
+    imul    rax, r9
+    sub     rdx, rax            ; inv -> rdx (64-bit approx)
+
+    lea     rsi, [rsi+r8*8]
+    lea     rdi, [rdi+r8*8]
+    neg     r8
+
+    mov     r10, rdx            ; inverse multiplier -> r10
+    xor     r11, r11
+    mov     rax, [rsi+r8*8]
+    or      rcx, rcx
+    mov     rdx, [rsi+r8*8+8]
+    jz      .4                  ; if divisor is odd
+    shrd    rax, rdx, cl
+    add     r8, 1
+    jmp     .6
+
+    xalign  16
+.3: mul     r9                  ; divisor is odd
+    mov     rax, [rsi+r8*8]
+    sub     rdx, r11
+    sub     rax, rdx
+    sbb     r11, r11
+.4: imul    rax, r10
+    mov     [rdi+r8*8], rax
+    add     r8, 1
+    jnz     .3
+    jmp     .7
+
+    xalign  16
+.5: mul     r9                  ; divisor is even
+    sub     rdx, r11
+    mov     rax, [rsi+r8*8-8]
+    mov     r11, [rsi+r8*8]
+    shrd    rax, r11, cl
+    sub     rax, rdx
+    sbb     r11, r11
+.6: imul    rax, r10
+    mov     [rdi+r8*8-8],rax
+    add     r8, 1
+    jnz     .5
+    mul     r9
+    mov     rax, [rsi-8]
+    sub     rdx, r11
+    shr     rax, cl
+    sub     rax, rdx
+    imul    rax, r10
+    mov     [rdi-8], rax
+.7: END_PROC reg_save_list
+
+    end

--- a/SMP/yasm/divexact_by3c.asm
+++ b/SMP/yasm/divexact_by3c.asm
@@ -1,0 +1,99 @@
+; PROLOGUE(mpn_divexact_by3c)
+
+; Version 1.0.4.
+;
+;  Copyright 2008 Jason Moxham and Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_divexact_by3c(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  mp_limb_t  mpn_divexact_by3(mp_ptr, mp_ptr, mp_size_t)
+;  rax                            rdi     rsi        rdx        rcx
+;  rax                            rcx     rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+    BITS 64
+
+%define MLT1 0x5555555555555555
+
+    xalign  16
+    LEAF_PROC mpn_divexact_by3c
+    mov     rax, r8
+    mov     r8, MLT1
+    imul    r9, r8
+    jmp     entry
+
+    xalign  16
+    LEAF_PROC mpn_divexact_by3
+    mov     rax, r8
+    mov     r8, MLT1
+    xor     r9, r9
+
+entry:
+    lea     r10, [rdx+rax*8-24]
+    lea     r11, [rcx+rax*8-24]
+    mov     ecx, 3
+    sub     rcx, rax
+    jnc     .2
+
+    xalign  16
+.1: mov     rax, [r10+rcx*8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+8], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+16]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+16], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+24]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+24], r9
+    sbb     r9, rdx
+    add     rcx, 4
+    jnc     .1
+.2: test    rcx, 2
+    jnz     .3
+    mov     rax, [r10+rcx*8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+8], r9
+    sbb     r9, rdx
+    add     rcx, 2
+.3: test    rcx, 1
+    jnz     .4
+    mov     rax, [r10+rcx*8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8], r9
+    sbb     r9, rdx
+.4:	lea     rax, [r9+r9*2]
+    neg     rax
+    ret
+
+    end

--- a/SMP/yasm/divexact_byfobm1.asm
+++ b/SMP/yasm/divexact_byfobm1.asm
@@ -1,0 +1,106 @@
+; PROLOGUE(mpn_divexact_byfobm1)
+
+;  Copyright 2008 Jason Moxham and Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later veSRCon.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  rcx[r8] = rdx[r8] / r9     where [rsp+40] must be set to (B - 1) / r9 on entry 
+;
+;  mp_limb_t mpn_divexact_byfobm1(mp_ptr, mp_ptr, mp_size_t, mp_limb_t, mp_limb_t)
+;  rax                             rdi     rsi        rdx        rcx         r8  
+;  rax                             rcx     rdx         r8         r9   [rsp+40]
+
+%include "yasm_mac.inc"
+
+%define CARRY_OUT
+
+    BITS 64
+
+    LEAF_PROC mpn_divexact_byfobm1
+    mov     rax, r8
+    mov     r8, [rsp+40]
+    
+%ifdef CARRY_OUT
+    mov     [rsp+32], r9
+%endif
+
+    lea     r10, [rdx+rax*8-24]
+    lea     r11, [rcx+rax*8-24]
+    mov     ecx, 3
+
+%ifdef CARRY_IN
+	mov		r9, [rsp+48]    ; r9 is the carry in
+    imul    r9, r8          ; this is needed if we have non-zero carry in
+%else
+    mov     r9, 0
+%endif
+
+    sub     rcx, rax
+    jnc     .2
+
+    xalign  16
+.1: mov     rax, [r10+rcx*8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+8], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+16]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+16], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+24]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+24], r9
+    sbb     r9, rdx
+    add     rcx, 4
+    jnc     .1
+.2: test    rcx, 2
+    jnz     .3
+    mov     rax, [r10+rcx*8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8], r9
+    sbb     r9, rdx
+    mov     rax, [r10+rcx*8+8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8+8], r9
+    sbb     r9, rdx
+    add     rcx, 2
+.3: test    rcx, 1
+    jnz     .4
+    mov     rax, [r10+rcx*8]
+    mul     r8
+    sub     r9, rax
+    mov     [r11+rcx*8], r9
+    sbb     r9, rdx
+.4: 
+
+%ifdef CARRY_OUT
+    imul    r9, [rsp+32]
+%endif
+
+    mov     rax, r9
+    neg     rax
+    ret
+
+    end

--- a/SMP/yasm/divrem_2.asm
+++ b/SMP/yasm/divrem_2.asm
@@ -1,0 +1,213 @@
+; PROLOGUE(mpn_divrem_2)
+
+;  x86-64 mpn_divrem_2 -- Divide an mpn number by a normalized 2-limb number.
+
+;  Copyright 2007, 2008 Free Software Foundation, Inc.
+
+;  Copyright Brian Gladman 2010 (Conversion to yasm format)
+
+;  This file is part of the GNU MP Library.
+
+;  The GNU MP Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 3 of the License, or (at
+;  your option) any later version.
+
+;  The GNU MP Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+
+;  mp_limb_t mpn_divrem_2(mp_ptr, mp_size_t, mp_ptr, mp_size_t,  mp_ptr)
+;  rax                       rdi        rsi     rdx        rcx       r8
+;  rax                       rcx        rdx      r8         r9 [rsp+40]
+
+%include 'yasm_mac.inc'
+
+    BITS 64
+	TEXT
+
+%define reg_save_list   rbx, rbp, rsi, rdi, r12, r13, r14, r15
+
+    xalign  16
+	WIN64_GCC_PROC mpn_divrem_2, 5, frame
+	lea     rax, [rdx+rcx*8]
+	mov     r13, rsi
+	lea     r12, [rax-24]
+	mov     rbp, rdi
+	mov     r11, [r8+8]
+	mov     r9, [rax-8]
+	mov     r8, [r8]
+	mov     r10, [rax-16]
+	xor     r15d, r15d
+	cmp     r11, r9
+	ja      .1
+	setb    dl
+	cmp     r8, r10
+	setbe   al
+	or      dl, al
+	jne     .10
+.1: lea     rbx, [rcx+r13-3]
+	test    rbx, rbx
+	js      .14
+	mov     rdx, r11
+	mov     rax, -1
+	not     rdx
+	div     r11
+	mov     rdx, r11
+	mov     rdi, rax
+	imul    rdx, rax
+	mov     r14, rdx
+	mul     r8
+	mov     rcx, rdx
+	mov     rdx, -1
+	add     r14, r8
+	adc     rdx, 0
+	add     r14, rcx
+	adc     rdx, 0
+	js      .3
+.2: dec     rdi
+	sub     r14, r11
+	sbb     rdx, 0
+	jns     .2
+.3:
+
+%ifdef  NEW
+
+	lea     rbp, [rbp+rbx*8]
+	mov     rcx, rbx
+	mov     rbx, r9
+	mov     r9, rdi
+	mov     r14, r10
+	mov     rsi, r11
+	neg     rsi
+	
+	xalign  16
+.4: mov     rax, r9
+	mul     rbx
+	add     rax, r14
+	mov     r10, rax
+	adc     rdx, rbx
+	mov     rdi, rdx
+	imul    rdx, rsi
+	mov     rax, r8
+	lea     rbx, [rdx+r14]
+	mul     rdi
+	xor     r14d, r14d
+	cmp     r13, rcx
+	jg      .5
+	mov     r14, [r12]
+	sub     r12, 8
+.5: sub     r14, r8
+	sbb     rbx, r11
+	sub     r14, rax
+	sbb     rbx, rdx
+	inc     rdi
+	xor     edx, edx
+	cmp     rbx, r10
+	mov     rax, r8
+	adc     rdx, -1
+	add     rdi, rdx
+	and     rax, rdx
+	and     rdx, r11
+	add     r14, rax
+	adc     rbx, rdx
+	cmp     rbx, r11
+	jae     .11
+.6:	mov     [rbp], rdi
+	sub     rbp, 8
+	dec     rcx
+	jns     .4
+
+	mov     r10, r14
+	mov     r9, rbx
+
+%else
+
+	lea     rbp, [rbp+rbx*8]
+	mov     rcx, rbx
+	mov     rax, r9
+	mov     rsi, r10
+	
+	xalign  16
+.7: mov     r14, rax
+	mul     rdi
+	mov     r9, r11
+	add     rax, rsi
+	mov     rbx, rax
+	adc     rdx, r14
+	lea     r10, [rdx+1]
+	mov     rax, rdx
+	imul    r9, rdx
+	sub     rsi, r9
+	xor     r9d, r9d
+	mul     r8
+	cmp     r13, rcx
+	jg      .8
+	mov     r9, [r12]
+	sub     r12, 8
+.8: sub     r9, r8
+	sbb     rsi, r11
+	sub     r9, rax
+	sbb     rsi, rdx
+	cmp     rsi, rbx
+	sbb     rax, rax
+	not     rax
+	add     r10, rax
+	mov     rbx, r8
+	and     rbx, rax
+	and     rax, r11
+	add     r9, rbx
+	adc     rax, rsi
+	cmp     r11, rax
+	jbe     .12
+.9: mov     [rbp], r10
+	sub     rbp, 8
+	mov     rsi, r9
+	dec     rcx
+	jns     .7
+
+	mov     r10, rsi
+	mov     r9, rax
+
+%endif
+
+    jmp     .14
+
+.10:inc     r15d
+	sub     r10, r8
+	sbb     r9, r11
+	jmp     .1
+
+%ifdef  NEW
+
+.11:seta    dl
+	cmp     r14, r8
+	setae   al
+	orb     al, dl
+	je      .6
+	inc     rdi
+	sub     r14, r8
+	sbb     rbx, r11
+	jmp     .6
+
+%else
+
+.12:jb      .13
+	cmp     r9, r8
+	jb      .9
+.13:inc     r10
+	sub     r9, r8
+	sbb     rax, r11
+	jmp     .9
+	
+%endif
+
+.14:mov     [r12+8], r10
+	mov     [r12+16], r9
+	mov     rax, r15
+	WIN64_GCC_END
+    
+    end

--- a/SMP/yasm/divrem_euclidean_qr_1.asm
+++ b/SMP/yasm/divrem_euclidean_qr_1.asm
@@ -1,0 +1,355 @@
+; PROLOGUE(mpn_divrem_euclidean_qr_1)
+
+;  x86-64 mpn_divrem_euclidean_qr_1 -- mpn by limb division.
+
+;  Copyright 2004, 2005, 2007, 2008, 2009 Free Software Foundation, Inc.
+
+;  Copyright Brian Gladman 2010 (Conversion to yasm format)
+
+;  This file is part of the GNU MP Library.
+
+;  The GNU MP Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 3 of the License, or (at
+;  your option) any later version.
+
+;  The GNU MP Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+
+;	mp_limb_t mpn_divrem_euclidean_qr_1(mp_ptr, mp_size_t, mp_ptr, mp_size_t, mp_limb_t)
+;   rax                                    rdi        rsi     rdx        rcx         r8
+;   rax                                    rcx        rdx      r8         r9   [rsp+40]
+
+;	mp_limb_t mpn_preinv_divrem_1(mp_ptr, mp_size_t, mp_ptr, mp_size_t, mp_limb_t, mp_limb_t,     int)
+;   rax                              rdi        rsi     rdx        rcx         r8         r9   8(rsp)
+;   rax                              rcx        rdx      r8         r9   [rsp+40]   [rsp+48] [rsp+56]
+
+%include 'yasm_mac.inc'
+
+    BITS 64
+	TEXT
+
+%define reg_save_list   rbx, rbp, rsi, rdi, r12, r13
+
+%define SPECIAL_CODE_FOR_NORMALIZED_DIVISOR
+
+	xalign  16
+	WIN64_GCC_PROC mpn_divrem_euclidean_qr_1, 5, frame
+	xor     eax, eax
+	mov     r12, rsi
+	mov     rbx, rcx
+	add     rcx, rsi
+	mov     rsi, rdx
+	je      .17
+
+	lea     rdi, [rdi+rcx*8-8]
+	xor     ebp, ebp
+
+%ifdef  SPECIAL_CODE_FOR_NORMALIZED_DIVISOR
+
+	test    r8, r8
+	jns     .6
+
+	test    rbx, rbx
+	je      .1
+	mov     rbp, [rsi+rbx*8-8]
+	dec     rbx
+	mov     rax, rbp
+	sub     rbp, r8
+	cmovb   rbp, rax
+	sbb     eax, eax
+	inc     eax
+	mov     [rdi], rax
+	lea     rdi, [rdi-8]
+.1: mov     rdx, r8
+	mov     rax, -1
+	not     rdx
+	div     r8
+	mov     r9, rax
+	mov     rax, rbp
+	jmp     .4
+
+	xalign  16
+.2: mov     r10, [rsi+rbx*8]
+	lea     rbp, [rax+1]
+	mul     r9
+	add     rax, r10
+	adc     rdx, rbp
+	mov     rbp, rax
+	mov     r13, rdx
+	imul    rdx, r8
+	sub     r10, rdx
+	mov     rax, r8
+	add     rax, r10
+	cmp     r10, rbp
+	cmovb   rax, r10
+	adc     r13, -1
+	cmp     rax, r8
+	jae     .5
+.3: mov     [rdi], r13
+	sub     rdi, 8
+.4: dec     rbx
+	jns     .2
+	xor     ecx, ecx
+	jmp     .14
+.5: sub     rax, r8
+	inc     r13
+	jmp     .3
+	
+%endif
+
+.6: test    rbx, rbx
+	je      .7
+	mov     rax, [rsi+rbx*8-8]
+	cmp     rax, r8
+	jae     .7
+	mov     [rdi], rbp
+	mov     rbp, rax
+	lea     rdi, [rdi-8]
+	je      .17
+	dec     rbx
+.7: bsr     rcx, r8
+	not     ecx
+	sal     r8, cl
+	sal     rbp, cl
+	mov     rdx, r8
+	mov     rax, -1
+	not     rdx
+	div     r8
+	test    rbx, rbx
+	mov     r9, rax
+	mov     rax, rbp
+	je      .14
+	mov     rbp, [rsi+rbx*8-8]
+	shr     rax, cl
+	shld    rax, rbp, cl
+	sub     rbx, 2
+	js      .10
+
+	xalign  16
+.8: nop
+	mov     r10, [rsi+rbx*8]
+	lea     r11, [rax+1]
+	shld    rbp, r10, cl
+	mul     r9
+	add     rax, rbp
+	adc     rdx, r11
+	mov     r11, rax
+	mov     r13, rdx
+	imul    rdx, r8
+	sub     rbp, rdx
+	mov     rax, r8
+	add     rax, rbp
+	cmp     rbp, r11
+	cmovb   rax, rbp
+	adc     r13, -1
+	cmp     rax, r8
+	jae     .12
+.9: mov     [rdi], r13
+	sub     rdi, 8
+	dec     rbx
+	mov     rbp, r10
+	jns     .8
+.10:lea     r11, [rax+1]
+	sal     rbp, cl
+	mul     r9
+	add     rax, rbp
+	adc     rdx, r11
+	mov     r11, rax
+	mov     r13, rdx
+	imul    rdx, r8
+	sub     rbp, rdx
+	mov     rax, r8
+	add     rax, rbp
+	cmp     rbp, r11
+	cmovb   rax, rbp
+	adc     r13, -1
+	cmp     rax, r8
+	jae     .13
+.11:mov     [rdi], r13
+	sub     rdi, 8
+	jmp     .14
+.12:sub     rax, r8
+	inc     r13
+	jmp     .9
+.13:sub     rax, r8
+	inc     r13
+	jmp     .11
+.14:mov     rbp, r8
+	neg     rbp
+	jmp     .16
+
+	xalign  16
+.15:lea     r11, [rax+1]
+	mul     r9
+	add     rdx, r11
+	mov     r11, rax
+	mov     r13, rdx
+	imul    rdx, rbp
+	mov     rax, r8
+	add     rax, rdx
+	cmp     rdx, r11
+	cmovb   rax, rdx
+	adc     r13, -1
+	mov     [rdi], r13
+	sub     rdi, 8
+.16:dec     r12
+	jns     .15
+	shr     rax, cl
+.17:WIN64_GCC_END
+
+%ifndef EXCLUDE_PREINV
+
+	xalign  16
+	WIN64_GCC_PROC mpn_preinv_divrem_1, 7, frame
+	xor     eax, eax
+	mov     r12, rsi
+	mov     rbx, rcx
+	add     rcx, rsi
+	mov     rsi, rdx
+	lea     rdi, [rdi+rcx*8-8]
+
+	test    r8, r8
+	js      .3
+	mov     cl, [rsp+stack_use+0x38]
+	shl     r8, cl
+	jmp     .7
+	
+%ifdef  SPECIAL_CODE_FOR_NORMALIZED_DIVISOR
+
+	xalign  16
+.1: mov     r10, [rsi+rbx*8]
+	lea     rbp, [rax+1]
+	mul     r9
+	add     rax, r10
+	adc     rdx, rbp
+	mov     rbp, rax
+	mov     r13, rdx
+	imul    rdx, r8
+	sub     r10, rdx
+	mov     rax, r8
+	add     rax, r10
+	cmp     r10, rbp
+	cmovb   rax, r10
+	adc     r13, -1
+	cmp     rax, r8
+	jae     .4
+.2: mov     [rdi], r13
+	sub     rdi, 8
+.3: dec     rbx
+	jns     .1
+	xor     ecx, ecx
+	jmp     .14
+.4: sub     rax, r8
+	inc     r13
+	jmp     .2
+	
+%endif
+
+.5: test    rbx, rbx
+	je      .6
+	mov     rax, [rsi+rbx*8-8]
+	cmp     rax, r8
+	jae     .6
+	mov     [rdi], rbp
+	mov     rbp, rax
+	lea     rdi, [rdi-8]
+	je      .17
+	dec     rbx
+.6: bsr     rcx, r8
+	not     ecx
+	sal     r8, cl
+	sal     rbp, cl
+	mov     rdx, r8
+	mov     rax, -1
+	not     rdx
+	div     r8
+	test    rbx, rbx
+	mov     r9, rax
+	mov     rax, rbp
+	je      .14
+.7: mov     rbp, [rsi+rbx*8-8]
+	shr     rax, cl
+	shld    rax, rbp, cl
+	sub     rbx, 2
+	js      .10
+
+	xalign  16
+.8: nop
+	mov     r10, [rsi+rbx*8]
+	lea     r11, [rax+1]
+	shld    rbp, r10, cl
+	mul     r9
+	add     rax, rbp
+	adc     rdx, r11
+	mov     r11, rax
+	mov     r13, rdx
+	imul    rdx, r8
+	sub     rbp, rdx
+	mov     rax, r8
+	add     rax, rbp
+	cmp     rbp, r11
+	cmovb   rax, rbp
+	adc     r13, -1
+	cmp     rax, r8
+	jae     .12
+.9: mov     [rdi], r13
+	sub     rdi, 8
+	dec     rbx
+	mov     rbp, r10
+	jns     .8
+.10:lea     r11, [rax+1]
+	sal     rbp, cl
+	mul     r9
+	add     rax, rbp
+	adc     rdx, r11
+	mov     r11, rax
+	mov     r13, rdx
+	imul    rdx, r8
+	sub     rbp, rdx
+	mov     rax, r8
+	add     rax, rbp
+	cmp     rbp, r11
+	cmovb   rax, rbp
+	adc     r13, -1
+	cmp     rax, r8
+	jae     .13
+.11:mov     [rdi], r13
+	sub     rdi, 8
+	jmp     .14
+.12:sub     rax, r8
+	inc     r13
+	jmp     .9
+.13:sub     rax, r8
+	inc     r13
+	jmp     .11
+.14:mov     rbp, r8
+	neg     rbp
+	jmp     .16
+
+	xalign  16
+.15:lea     r11, [rax+1]
+	mul     r9
+	add     rdx, r11
+	mov     r11, rax
+	mov     r13, rdx
+	imul    rdx, rbp
+	mov     rax, r8
+	add     rax, rdx
+	cmp     rdx, r11
+	cmovb   rax, rdx
+	adc     r13, -1
+	mov     [rdi], r13
+	sub     rdi, 8
+.16:dec     r12
+	jns     .15
+	shr     rax, cl
+.17:WIN64_GCC_END
+
+%endif
+
+    end

--- a/SMP/yasm/divrem_euclidean_qr_2.asm
+++ b/SMP/yasm/divrem_euclidean_qr_2.asm
@@ -1,0 +1,147 @@
+; PROLOGUE(mpn_divrem_euclidean_qr_2)
+
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_divrem_euclidean_qr_2(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  rax                                    rdi     rsi        rdx        rcx
+;  rax                                    rcx     rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+%define reg_save_list rbx, rsi, rdi, rbp, r12, r13, r14, r15
+
+    BITS 64
+
+	FRAME_PROC mpn_divrem_euclidean_qr_2, 0, reg_save_list
+	mov     rdi, rcx
+	mov     rsi, rdx
+	mov     rdx, r8
+    mov     rcx, r9
+
+	mov     rbx, rdx
+	dec     rbx
+	mov     r9, 0
+	mov     rdx, [rcx+8]
+	not     rdx
+	mov     rax, -1
+	div     qword[rcx+8]
+	mov     rbp, rax
+	mov     r8, [rsi+rbx*8]
+	dec     rbx
+	mov     r10, [rsi+rbx*8]
+	cmp     r8, [rcx+8]
+	jae     .1
+	mov     rdx, r8
+	mov     r9, r8
+	mov     r10, [rsi+rbx*8]
+	mov     r8, r10
+	mov     r14, 0
+	jmp     .3
+.1: mov     r14, 1
+	mov     rdx, r8
+	sub     rdx, [rcx+8]
+	sub     r10, [rcx]
+	sbb     rdx, 0
+	jnc     .2
+	dec     r14
+	add     r10, [rcx]
+	adc     rdx, [rcx+8]
+.2: mov     r9, rdx
+	mov     r8, r10
+.3: dec     rbx
+	mov     rax, r9
+	js      .8
+
+	xalign  16
+.4: cmp     rax, [rcx+8]
+	jne     .6
+	mov     r10, [rsi+rbx*8]
+	mov     r15, -1
+	mov     rdx, r8
+	add     r10, [rcx]
+	adc     rdx, rax
+	sbb     rax, rax
+	sub     rdx, [rcx]
+	adc     rax, 0
+	jz      .5
+	dec     r15
+	add     r10, [rcx]
+	adc     rdx, [rcx+8]
+.5: mov     rax, rdx
+	mov     r8, r10
+	jmp     .7
+.6:	mov     r9, rax
+	bt      r8, 63
+	adc     rax, 0
+	mov     r15, r8
+	mov     r13, 0
+	sar     r15, 63
+	and     r15, [rcx+8]
+	add     r15, r8
+	mul     rbp
+	add     rax, r15
+	mov     rax, [rcx]
+	adc     rdx, r9
+	mov     r10, rdx
+	mul     rdx
+	mov     r12, [rcx]
+	add     r12, rax
+	adc     r13, rdx
+	mov     rax, [rcx+8]
+	not     r10
+	mul     r10
+	sub     r9, [rcx+8]
+	add     rax, r8
+	adc     rdx, r9
+	mov     r9, rdx
+	and     r9, [rcx+8]
+	; swapped r9,rax from here
+	add     rax, r9
+	mov     r15, rdx
+	sub     r15, r10
+	and     rdx, [rcx]
+	sub     r12, rdx
+	sbb     r13, 0
+	mov     r8, [rsi+rbx*8]
+	sub     r8, r12
+	sbb     rax, r13
+	mov     r10, [rcx]
+	mov     r11, [rcx+8]
+	sbb     r9, r9
+	and     r10, r9
+	and     r11, r9
+	add     r15, r9
+	add     r8, r10
+	adc     rax, r11
+	adc     r9, 0
+	and     r10, r9
+	and     r11, r9
+	add     r15, r9
+	add     r8, r10
+	adc     rax, r11
+.7: mov     [rdi+rbx*8], r15
+	dec     rbx
+	jns     .4
+.8: mov     [rsi+8], rax
+	mov     [rsi], r8
+	mov     rax, r14
+    END_PROC reg_save_list
+	
+	end

--- a/SMP/yasm/modexact_1c_odd.asm
+++ b/SMP/yasm/modexact_1c_odd.asm
@@ -1,0 +1,98 @@
+; PROLOGUE(mpn_modexact_1c_odd)
+
+;  Copyright 1999, 2000, 2001, 2002 Free Software Foundation, Inc.
+;
+;  Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or
+;  modify it under the terms of the GNU Lesser General Public License as
+;  published by the Free Software Foundation; either version 2.1 of the
+;  License, or (at your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;  Lesser General Public License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public
+;  License along with the MPIR Library; see the file COPYING.LIB.  If
+;  not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+;  Fifth Floor, Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_modexact_1_odd(mp_ptr, mp_size_t, mp_limb_t)
+;  mp_limb_t mpn_modexact_1c_odd(mp_ptr, mp_size_t, mp_limb_t, mp_limb_t)
+;  rax                              rdi        rsi        rdx        rcx
+;  rax                              rcx        rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+%define reg_save_list       rsi, rdi
+
+    BITS 64
+    
+    extern  __gmp_binvert_limb_table
+
+    LEAF_PROC mpn_modexact_1_odd
+    mov     r9, 0               ; carry
+
+    FRAME_PROC mpn_modexact_1c_odd, 0, reg_save_list
+    
+    ; first use Newton's iteration to invert the divisor limb (d) using 
+    ; f(x) = 1/x - d  and x[i+1] = x[i] - f(x[i]) / f'(x[i]) to give
+    ; the iteration formula: x[i+1] = x[i] * (2 - d * x[i])
+    
+    mov     rsi, rdx
+    mov     rdx, r8    
+    shr     edx, 1              ; div / 2
+    lea     r10, [rel __gmp_binvert_limb_table]
+    and     edx, 127
+    movzx   edx, byte [rdx+r10] ; inv -> rdx (8-bit approx)
+
+    mov     rax, [rcx]          ; first limb of numerator
+    lea     r11, [rcx+rsi*8]    ; pointer to top of src
+    mov     rdi, r8             ; save divisor
+
+    lea     ecx, [rdx+rdx]
+    imul    edx, edx
+    neg     rsi                 ; limb offset from top of src
+    imul    edx, edi
+    sub     ecx, edx            ; inv -> rcx (16-bit approx)
+
+    lea     edx, [rcx+rcx]
+    imul    ecx, ecx
+    imul    ecx, edi
+    sub     edx, ecx            ; inv -> rdx (32-bit approx)
+    xor     ecx, ecx
+
+    lea     r10, [rdx+rdx]
+    imul    rdx, rdx
+    imul    rdx, r8
+    sub     r10, rdx            ; inv -> r10 (64-bit approx)
+
+    mov     rdx, r9             ; intial carry -> rdx
+    add     rsi, 1              ; adjust limb offset
+    jz      .2
+
+    mov     r9, r11
+    lea     rsi,[r11+rsi*8]
+    
+    xalign    16
+.1: sub     rax, rdx
+    adc     rcx, 0
+    imul    rax, r10
+    mul     r8
+    lodsq
+    sub     rax, rcx
+    setc    cl
+    cmp     r9, rsi
+    jne     .1
+.2: sub     rax, rdx
+    adc     rcx, 0
+    imul    rax, r10
+    mul     r8
+    lea     rax, [rcx+rdx]
+    END_PROC reg_save_list
+
+    end

--- a/SMP/yasm/mul_2.asm
+++ b/SMP/yasm/mul_2.asm
@@ -1,0 +1,141 @@
+; PROLOGUE(mpn_mul_2)
+
+;  X86_64 mpn_mul_2
+;
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_mul_2(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  rax                     rdi     rsi        rdx        rcx
+;  rax                     rcx     rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+%define reg_save_list rsi, rdi, rbx
+
+    BITS 64
+
+	FRAME_PROC mpn_mul_2, 0, reg_save_list
+	mov     rax, r8
+	
+	mov     r8, [r9]
+	lea     rsi, [rdx+rax*8-24]
+	lea     rdi, [rcx+rax*8-24]
+	mov     rcx, [r9+8]
+	mov     rbx, 3
+	sub     rbx, rax
+	mov     r10, 0
+	mov     rax, [rsi+rbx*8]
+	mul     r8
+	mov     r11, rax
+	mov     r9, rdx
+	cmp     rbx, 0
+	jge     .2
+	
+	xalign  16
+.1: mov     rax, [rsi+rbx*8]
+	mov     [rdi+rbx*8], r11
+	mul     rcx
+	add     r9, rax
+	adc     r10, rdx
+	mov     r11, 0
+	mov     rax, [rsi+rbx*8+8]
+	mul     r8
+	add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	adc     r11, 0
+	mul     rcx
+	add     r10, rax
+	mov     [rdi+rbx*8+8], r9
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     r8
+	mov     r9, 0
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	mov     [rdi+rbx*8+16], r10
+	mov     r10, 0
+	adc     r9, 0
+	mul     rcx
+	add     r11, rax
+	mov     rax, [rsi+rbx*8+24]
+	adc     r9, rdx
+	mul     r8
+	add     r11, rax
+	adc     r9, rdx
+	adc     r10, 0
+	add     rbx, 3
+	jnc     .1
+.2:	mov     rax, [rsi+rbx*8]
+	mov     [rdi+rbx*8], r11
+	mul     rcx
+	add     r9, rax
+	adc     r10, rdx
+	cmp     rbx, 1
+	ja      .5
+	je      .4
+.3:	mov     r11, 0
+	mov     rax, [rsi+rbx*8+8]
+	mul     r8
+	add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	adc     r11, 0
+	mul     rcx
+	add     r10, rax
+	mov     [rdi+rbx*8+8], r9
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     r8
+	mov     r9, 0
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	mov     [rdi+rbx*8+16], r10
+	adc     r9, 0
+	mul     rcx
+	add     r11, rax
+	adc     r9, rdx
+	mov     [rdi+rbx*8+24], r11
+	mov     rax, r9
+    EXIT_PROC reg_save_list
+
+	xalign  16
+.4:	mov     r11, 0
+	mov     rax, [rsi+rbx*8+8]
+	mul     r8
+	add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	adc     r11, 0
+	mul     rcx
+	add     r10, rax
+	mov     [rdi+rbx*8+8], r9
+	adc     r11, rdx
+	mov     [rdi+rbx*8+16], r10
+	mov     rax, r11
+    EXIT_PROC reg_save_list
+	
+	xalign  16
+.5:	mov     [rdi+rbx*8+8], r9
+	mov     rax, r10
+.6: END_PROC reg_save_list
+
+    end

--- a/SMP/yasm/mulmid_basecase.asm
+++ b/SMP/yasm/mulmid_basecase.asm
@@ -1,0 +1,415 @@
+; PROLOGUE(mpn_mulmid_basecase)
+;
+;  AMD64 mpn_mulmid_basecase
+;
+;  Based on mul_basecase.asm from GMP 4.3.1, modifications are copyright
+;  (C) 2009, David Harvey. The original mul_basecase.asm was released under
+;  LGPLv3+, license terms reproduced below. These modifications are hereby
+;  released under the same terms.
+;
+;  Windows Conversion Copyright 2010 Dr B R Gladman
+;
+;  Contributed to the GNU project by Torbjorn Granlund and David Harvey.
+;
+;  Copyright 2008 Free Software Foundation, Inc.
+;
+;  This file is part of the GNU MP Library.
+;
+;  The GNU MP Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 3 of the License, or (at
+;  your option) any later version.
+;
+;  The GNU MP Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public License
+;  //www.gnu.org/licenses/.
+;
+; void mpn_mulmid_basecase(mp_ptr, mp_ptr, mp_size_t, mp_ptr, mp_size_t)
+;  rax                        rdi     rsi        rdx     rcx         r8
+;  rax                        rcx     rdx         r8      r9   [rsp+40]
+
+%define reg_save_list   rbx, rsi, rdi, rbp, r12, r13, r14, r15
+
+%include 'yasm_mac.inc'
+
+        BITS 64
+	TEXT
+	
+	xalign  16
+	WIN64_GCC_PROC mpn_mulmid_basecase, 5, frame
+	mov     r15, rcx
+
+	lea     r13, [rdx+1]
+	sub     r13, r8
+	lea     rdi, [rdi+r13*8]
+	cmp     r13, 4
+	jc      .29
+	lea     rsi, [rsi+rdx*8]
+	test    r8, 1
+	jz      .10
+
+.0:	mov     ebx, r13d
+	neg     r13
+	mov     rax, [rsi+r13*8]
+	mov     r12, [r15]
+	mul     r12
+
+	and     r13, -4
+	mov     r11, r13
+
+	and     ebx, 3
+	jz      .2
+	cmp     ebx, 2
+	jc      .3
+	jz      .4
+
+.1:	mov     r10, rax
+	mov     rbx, rdx
+	lea     r14, [rel .23]
+	jmp     .8
+
+	xalign  16
+.2:	mov     rbp, rax
+	mov     r10, rdx
+	lea     r14, [rel .20]
+	jmp     .7
+
+	xalign  16
+.3:	add     r11, 4
+	mov     rcx, rax
+	mov     rbp, rdx
+	mov     r10d, 0
+	mov     rax, [rsi+r11*8]
+	lea     r14, [rel .21]
+	jmp     .6
+
+	xalign  16
+.4:	mov     rbx, rax
+	mov     rcx, rdx
+	mov     rax, [rsi+r11*8+24]
+	mov     ebp, 0
+	mov     r10d, 0
+	lea     r14, [rel .22]
+	jmp     .9
+
+	xalign  16
+.5:	mov     [rdi+r11*8-16], rbx
+	add     rcx, rax
+	mov     rax, [rsi+r11*8]
+	adc     rbp, rdx
+.6:	mov     ebx, 0
+	mul     r12
+	mov     [rdi+r11*8-8], rcx
+	add     rbp, rax
+	adc     r10, rdx
+.7:	mov     rax, [rsi+r11*8+8]
+	mul     r12
+	mov     [rdi+r11*8], rbp
+	add     r10, rax
+	adc     rbx, rdx
+.8:	mov     rax, [rsi+r11*8+16]
+	mul     r12
+	mov     [rdi+r11*8+8], r10
+	mov     ebp, 0
+	mov     r10, rbp
+	add     rbx, rax
+	mov     rax, [rsi+r11*8+24]
+	mov     rcx, rbp
+	adc     rcx, rdx
+.9:	mul     r12
+	add     r11, 4
+	js      .5
+	mov     [rdi-16], rbx
+	add     rcx, rax
+	mov     [rdi-8], rcx
+	mov     [rdi+8], rbp
+	adc     rbp, rdx
+	mov     [rdi], rbp
+	dec     r8
+	jz      .40
+	lea     rsi, [rsi-8]
+	lea     r15, [r15+8]
+	mov     r11, r13
+	mov     r12, [r15]
+	mov     r9, [r15+8]
+	jmp     r14
+
+	xalign  16
+.10:mov     ebx, r13d
+
+	neg     r13
+	mov     rax, [rsi+r13*8-8]
+	mov     r12, [r15]
+	mov     r9, [r15+8]
+	mul     r9
+	and     r13, -4
+	mov     r11, r13
+	and     ebx, 3
+	jz      .12
+	cmp     ebx, 2
+	jc      .13
+	jz      .14
+.11:mov     rcx, rax
+	mov     rbp, rdx
+	lea     r14, [rel .23]
+	jmp     .17
+
+	xalign  16
+.12:mov     rbx, rax
+	mov     rcx, rdx
+	lea     r14, [rel .20]
+	jmp     .16
+
+	xalign  16
+.13:mov     r10, rax
+	mov     rbx, rdx
+	mov     ecx, 0
+	lea     r14, [rel .21]
+	jmp     .19
+
+	xalign  16
+.14:mov     rbp, rax
+	mov     r10, rdx
+	mov     ebx, 0
+	mov     rax, [rsi+r11*8+16]
+	lea     r14, [rel .22]
+	jmp     .18
+
+	xalign  16
+.15:mov     rax, [rsi+r11*8-8]
+	mul     r9
+	add     rbx, rax
+	adc     rcx, rdx
+.16:mov     ebp, 0
+	mov     rax, [rsi+r11*8]
+	mul     r12
+	add     rbx, rax
+	mov     rax, [rsi+r11*8]
+	adc     rcx, rdx
+	adc     ebp, 0
+	mul     r9
+	add     rcx, rax
+	mov     [rdi+r11*8], rbx
+	adc     rbp, rdx
+.17:mov     rax, [rsi+r11*8+8]
+	mul     r12
+	mov     r10d, 0
+	add     rcx, rax
+	adc     rbp, rdx
+	mov     ebx, 0
+	adc     r10d, 0
+	mov     rax, [rsi+r11*8+8]
+	mov     [rdi+r11*8+8], rcx
+	mul     r9
+	add     rbp, rax
+	mov     rax, [rsi+r11*8+16]
+	adc     r10, rdx
+.18:mov     ecx, 0
+	mul     r12
+	add     rbp, rax
+	mov     rax, [rsi+r11*8+16]
+	adc     r10, rdx
+	adc     ebx, 0
+	mul     r9
+	add     r10, rax
+	mov     [rdi+r11*8+16], rbp
+	adc     rbx, rdx
+.19:mov     rax, [rsi+r11*8+24]
+	mul     r12
+	add     r10, rax
+	adc     rbx, rdx
+	adc     ecx, 0
+	add     r11, 4
+	mov     [rdi+r11*8-8], r10
+	jnz     .15
+	mov     [rdi], rbx
+	mov     [rdi+8], rcx
+	sub     r8, 2
+	jz      .40
+	lea     r15, [r15+16]
+	lea     rsi, [rsi-16]
+	mov     r11, r13
+	mov     r12, [r15]
+	mov     r9, [r15+8]
+	jmp     r14
+
+	xalign  16
+.20:mov     rax, [rsi+r11*8-8]
+	mul     r9
+	mov     rcx, rax
+	mov     rbp, rdx
+	mov     r10d, 0
+	jmp     .25
+
+	xalign  16
+.21:mov     rax, [rsi+r11*8+16]
+	mul     r9
+	mov     rbx, rax
+	mov     rcx, rdx
+	mov     ebp, 0
+	mov     rax, [rsi+r11*8+24]
+	jmp     .28
+
+	xalign  16
+.22:mov     rax, [rsi+r11*8+8]
+	mul     r9
+	mov     r10, rax
+	mov     rbx, rdx
+	mov     ecx, 0
+	jmp     .27
+
+	xalign  16
+.23:mov     rax, [rsi+r11*8]
+	mul     r9
+	mov     rbp, rax
+	mov     r10, rdx
+	mov     ebx, 0
+	mov     ecx, 0
+	jmp     .26
+	
+	xalign  16
+.24:mov     r10d, 0
+	add     rbx, rax
+	mov     rax, [rsi+r11*8-8]
+	adc     rcx, rdx
+	adc     ebp, 0
+	mul     r9
+	add     [rdi+r11*8-8], rbx
+	adc     rcx, rax
+	adc     rbp, rdx
+.25:mov     rax, [rsi+r11*8]
+	mul     r12
+	add     rcx, rax
+	mov     rax, [rsi+r11*8]
+	adc     rbp, rdx
+	adc     r10d, 0
+	mul     r9
+	add     [rdi+r11*8], rcx
+	mov     ecx, 0
+	adc     rbp, rax
+	mov     ebx, 0
+	adc     r10, rdx
+.26:mov     rax, [rsi+r11*8+8]
+	mul     r12
+	add     rbp, rax
+	mov     rax, [rsi+r11*8+8]
+	adc     r10, rdx
+	adc     ebx, 0
+	mul     r9
+	add     [rdi+r11*8+8], rbp
+	adc     r10, rax
+	adc     rbx, rdx
+.27:mov     rax, [rsi+r11*8+16]
+	mul     r12
+	add     r10, rax
+	mov     rax, [rsi+r11*8+16]
+	adc     rbx, rdx
+	adc     ecx, 0
+	mul     r9
+	add     [rdi+r11*8+16], r10
+	nop ; < not translated >
+	adc     rbx, rax
+	mov     ebp, 0
+	mov     rax, [rsi+r11*8+24]
+	adc     rcx, rdx
+.28:mul     r12
+	add     r11, 4
+	jnz     .24
+	add     rbx, rax
+	adc     rcx, rdx
+	adc     ebp, 0
+	add     [rdi-8], rbx
+	adc     [rdi], rcx
+	adc     [rdi+8], rbp
+	sub     r8, 2
+	jz      .40
+	lea     r15, [r15+16]
+	lea     rsi, [rsi-16]
+	mov     r11, r13
+	mov     r12, [r15]
+	mov     r9, [r15+8]
+	jmp     r14
+
+	xalign  16
+.29:xor     ebx, ebx
+	xor     ecx, ecx
+	xor     ebp, ebp
+	neg     r13
+	mov     eax, r8d
+	and     eax, 3
+	jz      .31
+	cmp     eax, 2
+	jc      .32
+	jz      .33
+.30:lea     r15, [r15-8]
+	mov     r10, r15
+	add     r8, 1
+	mov     r11, r8
+	lea     r14, [rel .36]
+	jmp     .36
+.31:mov     r10, r15
+	mov     r11, r8
+	lea     r14, [rip+0]
+	mov     rax, [rsi+r11*8-8]
+	jmp     .35
+.32:lea     r15, [r15+8]
+	mov     r10, r15
+	add     r8, 3
+	mov     r11, r8
+	lea     r14, [rip+0]
+	mov     rax, [r10-8]
+	jmp     .38
+.33:lea     r15, [r15-16]
+	mov     r10, r15
+	add     r8, 2
+	mov     r11, r8
+	lea     r14, [rip+0]
+	mov     rax, [r10+16]
+	jmp     .37
+
+	xalign  16
+.34:add     rbx, rax
+	adc     rcx, rdx
+	mov     rax, [rsi+r11*8-8]
+	adc     rbp, 0
+.35:mul     qword [r10]
+	add     rbx, rax
+	adc     rcx, rdx
+	adc     rbp, 0
+.36:mov     rax, [rsi+r11*8-16]
+	mul     qword [r10+8]
+	add     rbx, rax
+	mov     rax, [r10+16]
+	adc     rcx, rdx
+	adc     rbp, 0
+.37:mul     qword [rsi+r11*8-24]
+	add     rbx, rax
+	mov     rax, [r10+24]
+	adc     rcx, rdx
+	lea     r10, [r10+32]
+	adc     rbp, 0
+.38:mul     qword [rsi+r11*8-32]
+	sub     r11, 4
+	jnz     .34
+	add     rbx, rax
+	adc     rcx, rdx
+	adc     rbp, 0
+	mov     [rdi+r13*8], rbx
+	inc     r13
+	jz      .39
+	mov     r11, r8
+	mov     r10, r15
+	lea     rsi, [rsi+8]
+	mov     rbx, rcx
+	mov     rcx, rbp
+	xor     ebp, ebp
+	jmp     r14
+.39:mov     [rdi], rcx
+	mov     [rdi+8], rbp
+.40:WIN64_GCC_END
+
+	end

--- a/SMP/yasm/sandybridge/add_n.asm
+++ b/SMP/yasm/sandybridge/add_n.asm
@@ -1,0 +1,111 @@
+; PROLOGUE(mpn_add_n)
+
+;  Version 1.0.3.
+;
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  Calculate src1[size] plus(minus) src2[size] and store the result in
+;  dst[size].  The return value is the carry bit from the top of the result
+;  (1 or 0).  The _nc version accepts 1 or 0 for an initial carry into the
+;  low limb of the calculation.  Note values other than 1 or 0 here will
+;  lead to garbage results.
+;
+;  mp_limb_t  mpn_add_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;  mp_limb_t mpn_add_nc(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t, mp_limb_t)
+;  rax                     rdi        rsi        rdx        rcx         r8
+;  rax                     rcx        rdx         r8         r9   [rsp+40]
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+    xalign  8
+    LEAF_PROC mpn_add_nc
+    mov     r10,[rsp+40]
+    jmp     entry
+
+    xalign  8
+    LEAF_PROC mpn_add_n
+    xor     r10, r10
+entry:
+    mov     rax, r9
+    and     rax, 3
+    shr     r9, 2
+    lea     r9,[r10+r9*2]
+	sar     r9, 1
+    jnz     .2
+
+    mov     r10, [rdx]
+    adc     r10, [r8]
+    mov     [rcx], r10
+    dec     rax
+    jz      .1
+    mov     r10, [rdx+8]
+    adc     r10, [r8+8]
+    mov     [rcx+8], r10
+    dec     rax
+    jz      .1
+    mov     r10, [rdx+16]
+    adc     r10, [r8+16]
+    mov     [rcx+16], r10
+    dec     rax
+.1: adc     rax, rax
+    ret
+
+    xalign  8
+.2: mov     r10, [rdx]
+    mov     r11, [rdx+8]
+    lea     rdx, [rdx+32]
+    adc     r10, [r8]
+    adc     r11, [r8+8]
+    lea     r8, [r8+32]
+    mov     [rcx], r10
+    mov     [rcx+8], r11
+    lea     rcx, [rcx+32]
+    mov     r10, [rdx-16]
+    mov     r11, [rdx-8]
+    adc     r10, [r8-16]
+    adc     r11, [r8-8]
+    mov     [rcx-16], r10
+    dec     r9
+    mov     [rcx-8], r11
+    jnz     .2
+
+    inc     rax
+    dec     rax
+    jz      .3
+    mov     r10, [rdx]
+    adc     r10, [r8]
+    mov     [rcx], r10
+    dec     rax
+    jz      .3
+    mov     r10, [rdx+8]
+    adc     r10, [r8+8]
+    mov     [rcx+8], r10
+    dec     rax
+    jz      .3
+    mov     r10, [rdx+16]
+    adc     r10, [r8+16]
+    mov     [rcx+16], r10
+    dec     rax
+.3: adc     rax, rax
+    ret
+
+    end

--- a/SMP/yasm/sandybridge/addmul_1.asm
+++ b/SMP/yasm/sandybridge/addmul_1.asm
@@ -1,0 +1,156 @@
+; PROLOGUE(mpn_addmul_1)
+        
+;  Copyright 2011 The Code Cavern  
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_addmul_1(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  mp_limb_t mpn_inclsh_n(mp_ptr, mp_ptr, mp_size_t,   mp_uint)
+;  rax                       rdi     rsi        rdx        rcx
+;  rax                       rcx     rdx         r8        r9d
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi, r12
+
+        xalign 16
+        LEAF_PROC mpn_addmul_1
+        mov     rax, [rdx]
+        cmp     r8, 1
+        jnz     .1
+        mul     r9
+        add     [rcx], rax
+        adc     rdx, 0
+        mov     rax, rdx
+        ret
+
+        xalign   16
+.1:	    FRAME_PROC ?mpn_sandybridge_addmul, 0, reg_save_list
+        mov     r11, 5
+        lea     rsi, [rdx+r8*8-40]
+        lea     rdi, [rcx+r8*8-40]
+        mov     rcx, r9
+        sub     r11, r8
+        mul     rcx
+        db      0x26
+        mov     r8, rax
+        db      0x26
+        mov     rax, [rsi+r11*8+8]
+        db      0x26
+        mov     r9, rdx
+        db      0x26
+        cmp     r11, 0
+        db      0x26
+        mov     [rsp-8], r12
+        db      0x26
+        jge     .3
+.2:     xor     r10, r10
+        mul     rcx
+        add     [rdi+r11*8], r8
+        adc     r9, rax
+        adc     r10, rdx
+        mov     rax, [rsi+r11*8+16]
+        mul     rcx
+        add     [rdi+r11*8+8], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+r11*8+24]
+        xor     r8, r8
+        xor     r9, r9
+        mul     rcx
+        add     [rdi+r11*8+16], r10
+        adc     r12, rax
+        adc     r8, rdx
+        mov     rax, [rsi+r11*8+32]
+        mul     rcx
+        add     [rdi+r11*8+24], r12
+        adc     r8, rax
+        adc     r9, rdx
+        add     r11, 4
+        mov     rax, [rsi+r11*8+8]
+        jnc     .2
+.3      xor     r10, r10
+        mul     rcx
+        add     [rdi+r11*8], r8
+        adc     r9, rax
+        adc     r10, rdx
+        cmp     r11, 2
+        ja      .7
+        jz      .6
+        jp      .5
+.4:     mov     rax, [rsi+16]
+        mul     rcx
+        add     [rdi+8], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+24]
+        xor     r8, r8
+        xor     r9, r9
+        mul     rcx
+        add     [rdi+16], r10
+        adc     r12, rax
+        adc     r8, rdx
+        mov     rax, [rsi+32]
+        mul     rcx
+        add     [rdi+24], r12
+        adc     r8, rax
+        adc     r9, rdx
+        add     [rdi+32], r8
+        adc     r9, 0
+        mov     rax, r9
+        EXIT_PROC reg_save_list
+.5:     mov     rax, [rsi+24]
+        mul     rcx
+        add     [rdi+16], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+32]
+        xor     r8, r8
+        mul     rcx
+        add     [rdi+24], r10
+        adc     r12, rax
+        adc     r8, rdx
+        add     [rdi+32], r12
+        adc     r8, 0
+        mov     rax, r8
+        EXIT_PROC reg_save_list
+
+        align   16
+.6:     mov     rax, [rsi+32]
+        mul     rcx
+        add     [rdi+24], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        add     [rdi+32], r10
+        adc     r12, 0
+        mov     rax, r12
+        EXIT_PROC reg_save_list
+
+.7:     add     [rdi+32], r9
+        adc     r10, 0
+        mov     rax, r10
+        END_PROC reg_save_list
+
+        end

--- a/SMP/yasm/sandybridge/addmul_2.asm
+++ b/SMP/yasm/sandybridge/addmul_2.asm
@@ -1,0 +1,207 @@
+; PROLOGUE(mpn_addmul_2)
+
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.2 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_addmul_2(mp_ptr, mp_ptr, mp_size_t, mp_ptr)
+;  rax                       rdi     rsi        rdx     rcx
+;  rax                       rcx     rdx         r8      r9
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rbx, rsi, rdi, r12
+
+	FRAME_PROC mpn_addmul_2, 0, reg_save_list
+	mov     rdi, rcx
+	mov     rsi, rdx
+	mov     rax, r8
+	
+	mov     rcx, [r9]
+	mov     r8, [r9+8]
+	mov     rbx, 4
+	sub     rbx, rax
+	lea     rsi, [rsi+rax*8-32]
+	lea     rdi, [rdi+rax*8-32]
+	mov     r10, 0
+	mov     rax, [rsi+rbx*8]
+	mul     rcx
+	mov     r12, rax
+	mov     r9, rdx
+	cmp     rbx, 0
+	jge     .2
+	
+	xalign  16
+.1: mov     rax, [rsi+rbx*8]
+	mul     r8
+	add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     rcx
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	adc     r12, 0
+	mul     r8
+	add     [rdi+rbx*8+16], r10
+	mov     r9, 0
+	adc     r11, rax
+	mov     r10, 0
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	mov     r15, r15
+	mul     rcx
+	add     r11, rax
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	adc     r9, 0
+	mul     r8
+	add     [rdi+rbx*8+24], r11
+	adc     r12, rax
+	adc     r9, rdx
+	mov     rax, [rsi+rbx*8+32]
+	mul     rcx
+	add     r12, rax
+	adc     r9, rdx
+	adc     r10, 0
+	add     rbx, 4
+	jnc     .1
+.2:	mov     rax, [rsi+rbx*8]
+	mul     r8
+	cmp     rbx, 2
+	ja      .6
+	jz      .5
+	jp      .4
+.3: add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     rcx
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	adc     r12, 0
+	mul     r8
+	add     [rdi+rbx*8+16], r10
+	mov     r9, 0
+	adc     r11, rax
+	; padding
+	mov     r10, 0
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	; padding
+	mov     r15, r15
+	mul     rcx
+	add     r11, rax
+	mov     rax, [rsi+rbx*8+24]
+	adc     r12, rdx
+	adc     r9, 0
+	mul     r8
+	add     [rdi+rbx*8+24], r11
+	adc     r12, rax
+	adc     r9, rdx
+	mov     [rdi+rbx*8+32], r12
+	mov     rax, r9
+    EXIT_PROC reg_save_list
+
+	xalign  16
+.4: add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     rax, [rsi+rbx*8+16]
+	mul     rcx
+	add     r10, rax
+	mov     rax, [rsi+rbx*8+16]
+	adc     r11, rdx
+	adc     r12, 0
+	mul     r8
+	add     [rdi+rbx*8+16], r10
+	adc     r11, rax
+	adc     r12, rdx
+	mov     [rdi+rbx*8+24], r11
+	mov     rax, r12
+    EXIT_PROC reg_save_list
+	
+	xalign  16
+.5: add     r9, rax
+	mov     rax, [rsi+rbx*8+8]
+	adc     r10, rdx
+	mov     r11, 0
+	mul     rcx
+	add     [rdi+rbx*8], r12
+	adc     r9, rax
+	mov     r12, 0
+	adc     r10, rdx
+	mov     rax, [rsi+rbx*8+8]
+	adc     r11, 0
+	mul     r8
+	add     [rdi+rbx*8+8], r9
+	adc     r10, rax
+	adc     r11, rdx
+	mov     [rdi+rbx*8+16], r10
+	mov     rax, r11
+    EXIT_PROC reg_save_list
+
+	xalign  16
+.6: add     [rdi+rbx*8], r12
+	adc     r9, rax
+	adc     r10, rdx
+	mov     [rdi+rbx*8+8], r9
+	mov     rax, r10
+.7:	END_PROC reg_save_list
+
+    end

--- a/SMP/yasm/sandybridge/and_n.asm
+++ b/SMP/yasm/sandybridge/and_n.asm
@@ -1,0 +1,79 @@
+; PROLOGUE(mpn_and_n)
+
+;  mpn_and_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_and_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                    rcx        rdx         r8         r9
+;                    rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_and_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm1, [r8+r10*8+16]
+	movdqu  xmm3, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	pand    xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	pand    xmm1, xmm3
+	add     r10, 4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [r8+r10*8]
+	mov     rax, [r8+r10*8+16]
+	mov     r9, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	pand    xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	and     rax, r9
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm2, [rdx+r10*8]
+	pand    xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	ret
+
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	and     rax, r9
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/andn_n.asm
+++ b/SMP/yasm/sandybridge/andn_n.asm
@@ -1,0 +1,81 @@
+; PROLOGUE(mpn_andn_n)
+
+;  mpn_andn_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_andn_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                     rcx        rdx         r8         r9
+;                     rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+    
+	LEAF_PROC mpn_andn_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm1, [r8+r10*8+16]
+	movdqu  xmm3, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	pandn   xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	pandn   xmm1, xmm3
+	add     r10, 4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [r8+r10*8]
+	mov     rax, [r8+r10*8+16]
+	mov     r9, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	pandn   xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	not     rax
+	and     rax, r9
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm2, [rdx+r10*8]
+	pandn   xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	ret
+
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	not     rax
+	and     rax, r9
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/com_n.asm
+++ b/SMP/yasm/sandybridge/com_n.asm
@@ -1,0 +1,72 @@
+; PROLOGUE(mpn_com_n)
+
+;  mpn_com_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_com_n(mp_ptr, mp_ptr, mp_size_t)
+;                    rdi,    rsi,       rdx
+;                    rcx,    rdx,        r8
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_com_n
+	mov     r9, 3
+	lea     rdx, [rdx+r8*8-24]
+	pcmpeqb xmm2, xmm2
+	sub     r9, r8
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [rdx+r9*8]
+	movdqu  xmm1, [rdx+r9*8+16]
+	pxor    xmm0, xmm2
+	add     r9, 4
+	pxor    xmm1, xmm2
+	movdqu  [rcx], xmm0
+	movdqu  [rcx+16], xmm1
+	lea     rcx, [rcx+32]
+	jnc     .1
+.2:	cmp     r9, 2
+	ja      .6
+	je      .5
+	jp      .4
+.3:	movdqu  xmm0, [rdx+r9*8]
+	mov     rax, [rdx+r9*8+16]
+	pxor    xmm0, xmm2
+	not     rax
+	movdqu  [rcx], xmm0
+	mov     [rcx+16], rax
+	ret
+
+.4:	movdqu  xmm0, [rdx+r9*8]
+	pxor    xmm0, xmm2
+	movdqu  [rcx], xmm0
+	ret
+
+.5:	mov     rax, [rdx+r9*8]
+	not     rax
+	mov     [rcx], rax
+.6:	ret
+	
+	end

--- a/SMP/yasm/sandybridge/copyd.asm
+++ b/SMP/yasm/sandybridge/copyd.asm
@@ -1,0 +1,64 @@
+; PROLOGUE(mpn_copyd)
+
+;  mpn_copyd
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_copyi(mp_ptr, mp_ptr, mp_size_t)
+;                    rdi,    rsi,       rdx
+;                    rcx,    rdx,        r8
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_copyd
+	lea     rdx, [rdx+16]
+	lea     rcx, [rcx+16]
+	sub     r8, 4
+	jc      .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [rdx+r8*8]
+	movdqu  xmm1, [rdx+r8*8-16]
+	sub     r8, 4
+	movdqu  [rcx+r8*8-16+32], xmm1
+	movdqu  [rcx+r8*8+32], xmm0
+	jnc     .1
+.2:	cmp     r8, -2
+	jg      .5
+	je      .6
+	jnp     .4
+.3:	mov     rax, [rdx+r8*8+8]
+	mov     [rcx+r8*8+8], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [rdx+r8*8]
+	mov     rax, [rdx+r8*8-8]
+	mov     [rcx+r8*8-8], rax
+	movdqu  [rcx+r8*8], xmm0
+	ret
+
+.6:	movdqu  xmm0, [rdx+r8*8]
+	movdqu  [rcx+r8*8], xmm0
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/copyi.asm
+++ b/SMP/yasm/sandybridge/copyi.asm
@@ -1,0 +1,199 @@
+; PROLOGUE(mpn_copyi)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  void mpn_copyi(mp_ptr, mp_ptr, mp_size_t)
+;                    rdi     rsi        rdx
+;                    rcx     rdx         r8
+
+%define SMALL_LOOP  1
+
+%include "yasm_mac.inc"
+
+    CPU  Core2
+    BITS 64
+
+	LEAF_PROC mpn_copyi
+    cmp     r8, 0
+	jz      .9
+%if SMALL_LOOP <> 0
+	cmp     r8, 10
+	jge     .2
+	
+	xalign  16
+.1:	mov     rax, [rdx]
+	mov     [rcx], rax
+	lea     rdx, [rdx+8]
+	lea     rcx, [rcx+8]
+	sub     r8, 1
+	jnz     .1
+	ret
+%endif
+
+.2:	mov     rax, rcx
+	sub     rax, rdx
+	test    rax, 0xF
+	jz      .17
+	test    rcx, 0xF
+	jz      .10
+	mov     r9, 5
+	sub     r9, r8
+	lea     rdx, [rdx+r8*8-40]
+	lea     rcx, [rcx+r8*8-40]
+	movapd  xmm1, [rdx+r9*8]
+	movq    [rcx+r9*8], xmm1
+	add     rcx, 8
+%if SMALL_LOOP = 0
+	cmp     r8, 1
+	jz      .9
+%endif
+	cmp     r9, 0
+	jge     .4
+
+	xalign  16
+.3:	movapd  xmm0, [rdx+r9*8+16]
+	add     r9, 4
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8-32], xmm1
+	movapd  xmm1, [rdx+r9*8+0]
+	shufpd  xmm0, xmm1, 1
+	movapd  [rcx+r9*8-16], xmm0
+	jnc     .3
+.4:	cmp     r9, 2
+	ja      .8
+	jz      .7
+	jp      .6
+
+	xalign  16
+.5:	movapd  xmm0, [rdx+r9*8+16]
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8], xmm1
+	movapd  xmm1, [rdx+r9*8+32]
+	shufpd  xmm0, xmm1, 1
+	movapd  [rcx+r9*8+16], xmm0
+	ret
+
+	xalign  16
+.6:	movapd  xmm0, [rdx+r9*8+16]
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8], xmm1
+	movhpd  [rcx+r9*8+16], xmm0
+	ret
+
+	xalign  16
+.7:	movapd  xmm0, [rdx+r9*8+16]
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8], xmm1
+	ret
+
+	xalign  16
+.8:	movhpd  [rcx+r9*8], xmm1
+.9:	ret
+
+.10:mov     r9, 4
+	sub     r9, r8
+	lea     rdx, [rdx+r8*8-32]
+	lea     rcx, [rcx+r8*8-32]
+	movapd  xmm1, [rdx+r9*8-8]
+	sub     rdx, 8
+	cmp     r9, 0
+	jge     .12
+
+	xalign  16
+.11:movapd  xmm0, [rdx+r9*8+16]
+	add     r9, 4
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8-32], xmm1
+	movapd  xmm1, [rdx+r9*8+0]
+	shufpd  xmm0, xmm1, 1
+	movapd  [rcx+r9*8-16], xmm0
+	jnc     .11
+.12:cmp     r9, 2
+	ja      .16
+	jz      .15
+	jp      .14
+
+	xalign  16
+.13:movapd  xmm0, [rdx+r9*8+16]
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8], xmm1
+	movapd  xmm1, [rdx+r9*8+32]
+	shufpd  xmm0, xmm1, 1
+	movapd  [rcx+r9*8+16], xmm0
+	ret
+
+	xalign  16
+.14:movapd  xmm0, [rdx+r9*8+16]
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8], xmm1
+	movhpd  [rcx+r9*8+16], xmm0
+	ret
+	
+	xalign  16
+.15:movapd  xmm0, [rdx+r9*8+16]
+	shufpd  xmm1, xmm0, 1
+	movapd  [rcx+r9*8], xmm1
+	ret
+
+	xalign  16
+.16:movhpd  [rcx+r9*8], xmm1
+	ret
+
+	xalign  16
+.17:mov     r9, 3
+	sub     r9, r8
+	test    rcx, 0xF
+	lea     rdx, [rdx+r8*8-24]
+	lea     rcx, [rcx+r8*8-24]
+	jz      .18
+	mov     rax, [rdx+r9*8]
+	mov     [rcx+r9*8], rax
+	add     r9, 1
+.18:cmp     r9, 0
+	jge     .20
+
+	xalign  16
+.19:add     r9, 4
+	movapd  xmm0, [rdx+r9*8-32]
+	movapd  [rcx+r9*8-32], xmm0
+	movapd  xmm1, [rdx+r9*8-16]
+	movapd  [rcx+r9*8-16], xmm1
+	jnc     .19
+.20:cmp     r9, 2
+	ja      .22
+	je      .24
+	jp      .23
+
+.21:movapd  xmm0, [rdx+r9*8]
+	movapd  [rcx+r9*8], xmm0
+	mov     rax, [rdx+r9*8+16]
+	mov     [rcx+r9*8+16], rax
+.22:ret
+
+	xalign  16
+.23:movapd  xmm0, [rdx+r9*8]
+	movapd  [rcx+r9*8], xmm0
+	ret
+
+	xalign  16
+.24:mov     rax, [rdx+r9*8]
+	mov     [rcx+r9*8], rax
+	ret
+
+	end

--- a/SMP/yasm/sandybridge/divexact_byff.asm
+++ b/SMP/yasm/sandybridge/divexact_byff.asm
@@ -1,0 +1,73 @@
+; PROLOGUE(mpn_divexact_byff)
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_divexact_byff(mp_ptr, mp_ptr, mp_size_t)
+;  rax                           rdi     rsi         rdx
+;  rax                           rcx     rdx          r8 
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+    LEAF_PROC mpn_divexact_byff
+	mov     rax, 3
+	and     rax, r8
+	mov     [rsp+24], rax
+	xor     eax, eax
+	shr     r8, 2
+	cmp     r8, 0
+	je      .2
+; want carry clear here
+	xalign  16
+.1:	sbb     rax, [rdx]
+	lea     rcx, [rcx+32]
+	mov     r9, rax
+	sbb     rax, [rdx+8]
+	mov     r10, rax
+	sbb     rax, [rdx+16]
+	mov     r11, rax
+	sbb     rax, [rdx+24]
+	dec     r8
+	mov     [rcx-32], r9
+	mov     [rcx-24], r10
+	mov     [rcx-16], r11
+	mov     [rcx-8], rax
+	lea     rdx, [rdx+32]
+	jnz     .1
+.2:	mov     r8, [rsp+24]
+; dont want to change the carry
+	inc     r8
+	dec     r8
+	jz      .3
+	sbb     rax, [rdx]
+	mov     [rcx], rax
+	dec     r8
+	jz      .3
+	sbb     rax, [rdx+8]
+	mov     [rcx+8], rax
+	dec     r8
+	jz      .3
+	sbb     rax, [rdx+16]
+	mov     [rcx+16], rax
+.3:	sbb     rax, 0
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/divrem_hensel_qr_1_1.asm
+++ b/SMP/yasm/sandybridge/divrem_hensel_qr_1_1.asm
@@ -1,0 +1,91 @@
+; PROLOGUE(mpn_divrem_hensel_qr_1_1)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_divrem_hensel_qr_1_1(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  rax                                    rdi     rsi        rdx        rcx
+;  rax                                    rcx     rdx         r8         r9
+
+%include 'yasm_mac.inc'
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi
+
+    FRAME_PROC mpn_divrem_hensel_qr_1_1, 0, reg_save_list
+    mov     rax, r8
+	lea     rdi, [rcx+rax*8]
+	lea     rsi, [rdx+rax*8]
+	mov     rcx, r9
+	mov     r9, 0
+	sub     r9, rax
+	
+	mov     rdx, rcx
+	
+	mov     rax, rdx
+	imul    edx, ecx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11d, eax
+
+	mov     rax, r11
+	imul    r11d, ecx
+	mov     rdx, 2
+	sub     rdx, r11
+	imul    edx, eax
+
+	mov     rax, rdx
+	imul    edx, ecx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11d, eax
+
+	mov     rax, r11
+	imul    r11d, ecx
+	mov     rdx, 2
+	sub     rdx, r11
+	imul    edx, eax
+
+	mov     rax, rdx
+	imul    rdx, rcx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11, rax
+
+	xor     rdx, rdx
+
+	xalign  16
+.1:	mov     rax, [rsi+r9*8]
+	sbb     rax, rdx
+	sbb     r8, r8
+	imul    rax, r11
+	mov     [rdi+r9*8], rax
+	mul     rcx
+	add     r8, 1
+	inc     r9
+	jnz     .1
+	mov     rax, 0
+	adc     rax, rdx
+	END_PROC reg_save_list
+	
+	end

--- a/SMP/yasm/sandybridge/hamdist.asm
+++ b/SMP/yasm/sandybridge/hamdist.asm
@@ -1,0 +1,53 @@
+; PROLOGUE(mpn_hamdist)
+
+;  AMD64 mpn_hamdist
+;  Copyright 2009 Jason Moxham
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;	mp_limb_t mpn_hamdist(mp_ptr, mp_ptr, mp_size_t)
+;	rax                      rdi,    rsi,       rdx
+;	rax                      rcx,    rdx,        r8
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_hamdist
+	lea     rdx, [rdx+r8*8-8]
+	lea     r9, [rcx+r8*8-8]
+	mov     rcx, 1
+	xor     eax, eax
+	sub     rcx, r8
+	jnc     .1
+	xalign  16
+.0:	mov     r10, [r9+rcx*8]
+	xor     r10, [rdx+rcx*8]
+	popcnt  r10, r10
+	mov     r11, [r9+rcx*8+8]
+	xor     r11, [rdx+rcx*8+8]
+	popcnt  r11, r11
+	add     rax, r10
+	add     rax, r11
+	add     rcx, 2
+	jnc     .0
+.1: jne     .2
+	mov     r10, [r9+rcx*8]
+	xor     r10, [rdx+rcx*8]
+	popcnt  r10, r10
+	add     rax, r10
+.2:	ret
+
+    end

--- a/SMP/yasm/sandybridge/ior_n.asm
+++ b/SMP/yasm/sandybridge/ior_n.asm
@@ -1,0 +1,79 @@
+; PROLOGUE(mpn_ior_n)
+
+;  mpn_ior_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_ior_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                    rcx        rdx         r8         r9
+;                    rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_ior_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm1, [r8+r10*8+16]
+	movdqu  xmm3, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	por     xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	por     xmm1, xmm3
+	add     r10, 4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [r8+r10*8]
+	mov     rax, [r8+r10*8+16]
+	mov     r9, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	por     xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	or      rax, r9
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm2, [rdx+r10*8]
+	por     xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	ret
+
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	or      rax, r9
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/iorn_n.asm
+++ b/SMP/yasm/sandybridge/iorn_n.asm
@@ -1,0 +1,86 @@
+; PROLOGUE(mpn_iorn_n)
+
+;  mpn_iorn_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_iorn_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                     rcx        rdx         r8         r9
+;                     rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_iorn_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	pcmpeqb xmm4, xmm4
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [rdx+r10*8]
+	movdqu  xmm1, [rdx+r10*8+16]
+	movdqu  xmm2, [r8+r10*8]
+	add     r10, 4
+	movdqu  xmm3, [r8+r10*8+16-32]
+	pandn   xmm1, xmm3
+	pandn   xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8-32], xmm0
+	pxor    xmm1, xmm4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [rdx+r10*8]
+	mov     rax, [r8+r10*8+16]
+	movdqu  xmm2, [r8+r10*8]
+	mov     r9, [rdx+r10*8+16]
+	not     rax
+	or      rax, r9
+	pandn   xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [rdx+r10*8]
+	movdqu  xmm2, [r8+r10*8]
+	pandn   xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	ret
+
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	not     rax
+	or      rax, r9
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/karaadd.asm
+++ b/SMP/yasm/sandybridge/karaadd.asm
@@ -1,0 +1,242 @@
+; PROLOGUE(mpn_karaadd)
+;  mpn_karaadd  
+;       
+;  Copyright 2011 The Code Cavern  
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;       
+;  This file is part of the MPIR Library.  
+;       
+;  The MPIR Library is free software; you can redistribute it and/or modify  
+;  it under the terms of the GNU Lesser General Public License as published  
+;  by the Free Software Foundation; either version 2.1 of the License, or (at  
+;  your option) any later version.  
+;        
+;  The MPIR Library is distributed in the hope that it will be useful, but  
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public  
+;  License for more details.  
+;        
+;  You should have received a copy of the GNU Lesser General Public License  
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write  
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,  
+;  Boston, MA 02110-1301, USA.  
+;
+;  void mpn_karaadd(mp_ptr, mp_ptr, mp_size_t)
+;  rax                 rdi     rsi        rdx
+;  rax                 rcx     rdx         r8
+
+%include "yasm_mac.inc"
+
+%define reg_save_list   rbx, rbp, rsi, rdi, r12, r13, r14, r15
+
+    BITS 64
+    TEXT
+
+;   requires n >= 8  
+        FRAME_PROC mpn_karaadd, 1, reg_save_list
+        mov     rdi, rcx
+        mov     rsi, rdx
+        mov     rdx, r8
+        mov     [rsp], rdx
+;rp is rdi  
+;tp is rsi  
+;n is rdx and put it on the stack  
+        shr     rdx, 1
+;n2 is rdx  
+        lea     rcx, [rdx+rdx*1]
+; 2*n2 is rcx  
+; L is rdi  
+; H is rbp  
+; tp is rsi  
+        lea     rbp, [rdi+rcx*8]
+        xor     rax, rax
+        xor     rbx, rbx
+; rax rbx are the carrys  
+        lea     rdi, [rdi+rdx*8-24]
+        lea     rsi, [rsi+rdx*8-24]
+        lea     rbp, [rbp+rdx*8-24]
+        mov     ecx, 3
+        sub     rcx, rdx
+        mov     edx, 3
+        align   16
+lp:     bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp+rcx*8]
+        mov     r12, r8
+        mov     r9, [rdi+rdx*8+8]
+        adc     r9, [rbp+rcx*8+8]
+        mov     r10, [rdi+rdx*8+16]
+        adc     r10, [rbp+rcx*8+16]
+        mov     r11, [rdi+rdx*8+24]
+        adc     r11, [rbp+rcx*8+24]
+        rcl     rbx, 1
+        bt      rax, 1
+        mov     r15, r11
+        adc     r8, [rdi+rcx*8]
+        mov     r13, r9
+        adc     r9, [rdi+rcx*8+8]
+        mov     r14, r10
+        adc     r10, [rdi+rcx*8+16]
+        adc     r11, [rdi+rcx*8+24]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        adc     r13, [rbp+rdx*8+8]
+        adc     r14, [rbp+rdx*8+16]
+        adc     r15, [rbp+rdx*8+24]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rsi+rcx*8]
+        adc     r9, [rsi+rcx*8+8]
+        adc     r10, [rsi+rcx*8+16]
+        adc     r11, [rsi+rcx*8+24]
+        mov     [rdi+rdx*8+16], r10
+        mov     [rdi+rdx*8+24], r11
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        mov     [rdi+rdx*8+8], r9
+        adc     r12, [rsi+rdx*8]
+        adc     r13, [rsi+rdx*8+8]
+        adc     r14, [rsi+rdx*8+16]
+        adc     r15, [rsi+rdx*8+24]
+        rcl     rbx, 1
+        add     rdx, 4
+        mov     [rbp+rcx*8], r12
+        mov     [rbp+rcx*8+8], r13
+        mov     [rbp+rcx*8+16], r14
+        mov     [rbp+rcx*8+24], r15
+        add     rcx, 4
+        jnc     lp
+        cmp     rcx, 2
+        jg      case0
+        jz      case1
+        jp      case2
+case3:  
+        bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp]
+        mov     r12, r8
+        mov     r9, [rdi+rdx*8+8]
+        adc     r9, [rbp+8]
+        mov     r10, [rdi+rdx*8+16]
+        adc     r10, [rbp+16]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rdi]
+        mov     r13, r9
+        adc     r9, [rdi+8]
+        mov     r14, r10
+        adc     r10, [rdi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        adc     r13, [rbp+rdx*8+8]
+        adc     r14, [rbp+rdx*8+16]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rsi]
+        adc     r9, [rsi+8]
+        adc     r10, [rsi+16]
+        mov     [rdi+rdx*8+16], r10
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        mov     [rdi+rdx*8+8], r9
+        adc     r12, [rsi+rdx*8]
+        adc     r13, [rsi+rdx*8+8]
+        adc     r14, [rsi+rdx*8+16]
+        rcl     rbx, 1
+        add     rdx, 3
+        mov     [rbp], r12
+        mov     [rbp+8], r13
+        mov     [rbp+16], r14
+        jmp     fin
+case2:  
+        bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp+8]
+        mov     r12, r8
+        mov     r9, [rdi+rdx*8+8]
+        adc     r9, [rbp+16]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rdi+8]
+        mov     r13, r9
+        adc     r9, [rdi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        adc     r13, [rbp+rdx*8+8]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rsi+8]
+        adc     r9, [rsi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        mov     [rdi+rdx*8+8], r9
+        adc     r12, [rsi+rdx*8]
+        adc     r13, [rsi+rdx*8+8]
+        rcl     rbx, 1
+        add     rdx, 2
+        mov     [rbp+8], r12
+        mov     [rbp+16], r13
+        jmp     fin
+case1:  
+        bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp+16]
+        mov     r12, r8
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rdi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rsi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        adc     r12, [rsi+rdx*8]
+        rcl     rbx, 1
+        inc     rdx
+        mov     [rbp+rcx*8], r12
+fin:    mov     rcx, 3
+case0:  
+        mov     r8, [rsp]
+        bt      r8, 0
+        jnc     notodd
+        xor     r10, r10
+        mov     r8, [rbp+rdx*8]
+        mov     r9, [rbp+rdx*8+8]
+        add     r8, [rsi+rdx*8]
+        adc     r9, [rsi+rdx*8+8]
+        rcl     r10, 1
+        add     [rbp+24], r8
+        adc     [rbp+32], r9
+        adc     [rbp+40], r10
+l7:     adc     qword[rbp+rcx*8+24], 0
+        inc     rcx
+        jc      l7
+        mov     rcx, 3
+notodd: and     rax, 3
+        popcnt  r8, rax
+        bt      rbx, 2
+        adc     r8, 0
+        adc     [rdi+rdx*8], r8
+l1:     adc     qword[rdi+rdx*8+8], 0
+        inc     rdx
+        jc      l1
+        and     rbx, 7
+        popcnt  r8, rbx
+        add     [rbp+24], r8
+l2:     adc     qword[rbp+rcx*8+8], 0
+        inc     rcx
+        jc      l2
+        END_PROC reg_save_list
+
+        end

--- a/SMP/yasm/sandybridge/karasub.asm
+++ b/SMP/yasm/sandybridge/karasub.asm
@@ -1,0 +1,345 @@
+; PROLOGUE(mpn_karasub)
+;  mpn_karasub  
+;       
+;  Copyright 2011 The Code Cavern  
+;
+;  Copyright 2012 Brian Gladman
+;       
+;  This file is part of the MPIR Library.  
+;       
+;  The MPIR Library is free software; you can redistribute it and/or modify  
+;  it under the terms of the GNU Lesser General Public License as published  
+;  by the Free Software Foundation; either version 2.1 of the License, or (at  
+;  your option) any later version.  
+;        
+;  The MPIR Library is distributed in the hope that it will be useful, but  
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY  
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public  
+;  License for more details.  
+;        
+;  You should have received a copy of the GNU Lesser General Public License  
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write  
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,  
+;  Boston, MA 02110-1301, USA.  
+;
+;  void mpn_karasub(mp_ptr, mp_ptr, mp_size_t)
+;  rax                 rdi     rsi        rdx
+;  rax                 rcx     rdx         r8
+;
+;  Karasuba Multiplication - split x and y into two equal length halves so
+;  that x = xh.B + xl and y = yh.B + yl. Then their product is:
+;
+;  x.y = xh.yh.B^2 + (xh.yl + xl.yh).B + xl.yl
+;      = xh.yh.B^2 + (xh.yh + xl.yl - {xh - xl}.{yh - yl}).B + xl.yl
+;
+; If the length of the elements is m (about n / 2), the output length is 4 * m 
+; as illustrated below.  The middle two blocks involve three additions and one 
+; subtraction: 
+; 
+;       -------------------- rp
+;       |                  |-->
+;       |   A:xl.yl[lo]    |   |
+;       |                  |   |      (xh - xl).(yh - yl)
+;       --------------------   |      -------------------- tp
+;  <--  |                  |<--<  <-- |                  |
+; |     |   B:xl.yl[hi]    |   |      |     E:[lo]       |
+; |     |                  |   |      |                  |
+; |     --------------------   |      --------------------
+; >-->  |                  |-->   <-- |                  |
+; |\___ |   C:xh.yh[lo]    | ____/    |     F:[hi]       |
+; |     |                  |          |                  |
+; |     --------------------          --------------------
+;  <--  |                  |   
+;       |   D:xh.yh[hi]    |
+;       |                  |
+;       --------------------
+;
+; To avoid overwriting B before it is used, we need to do two operations
+; in parallel:
+;
+; (1)   B = B + C + A - E = (B + C) + A - E
+; (2)   C = C + B + D - F = (B + C) + D - F
+;
+; The final carry from (1) has to be propagated into C and D, and the final
+; carry from (2) has to be propagated into D. When the number of input limbs
+; is odd, some extra operations have to be undertaken. 
+
+%include "yasm_mac.inc"
+
+%define reg_save_list   rbx, rbp, rsi, rdi, r12, r13, r14, r15
+
+%macro add_one 1
+    inc     %1
+%endmacro
+
+    BITS 64
+    TEXT
+        
+;       requires n >= 8  
+        FRAME_PROC mpn_karasub, 2, reg_save_list
+        mov     rdi, rcx
+        mov     rsi, rdx
+        mov     rdx, r8
+        mov     [rsp], rdx
+        mov     [rsp+8], rdi
+
+;       rp is rdi, tp is rsi, L is rdi, H is rbp, tp is rsi
+;       carries/borrows in rax, rbx
+   
+        shr     rdx, 1
+        lea     rcx, [rdx+rdx*1]
+        lea     rbp, [rdi+rcx*8]
+        xor     rax, rax
+        xor     rbx, rbx
+        lea     rdi, [rdi+rdx*8-24]
+        lea     rsi, [rsi+rdx*8-24]
+        lea     rbp, [rbp+rdx*8-24]
+        mov     ecx, 3
+        sub     rcx, rdx
+        mov     edx, 3
+
+        align   16
+.1:     bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp+rcx*8]
+        mov     r12, r8
+        mov     r9, [rdi+rdx*8+8]
+        adc     r9, [rbp+rcx*8+8]
+        mov     r10, [rdi+rdx*8+16]
+        adc     r10, [rbp+rcx*8+16]
+        mov     r11, [rdi+rdx*8+24]
+        adc     r11, [rbp+rcx*8+24]
+        rcl     rbx, 1
+        bt      rax, 1
+        mov     r15, r11
+        adc     r8, [rdi+rcx*8]
+        mov     r13, r9
+        adc     r9, [rdi+rcx*8+8]
+        mov     r14, r10
+        adc     r10, [rdi+rcx*8+16]
+        adc     r11, [rdi+rcx*8+24]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        adc     r13, [rbp+rdx*8+8]
+        adc     r14, [rbp+rdx*8+16]
+        adc     r15, [rbp+rdx*8+24]
+        rcl     rbx, 1
+        bt      rax, 1
+        sbb     r8, [rsi+rcx*8]
+        sbb     r9, [rsi+rcx*8+8]
+        sbb     r10, [rsi+rcx*8+16]
+        sbb     r11, [rsi+rcx*8+24]
+        mov     [rdi+rdx*8+16], r10
+        mov     [rdi+rdx*8+24], r11
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        mov     [rdi+rdx*8+8], r9
+        sbb     r12, [rsi+rdx*8]
+        sbb     r13, [rsi+rdx*8+8]
+        sbb     r14, [rsi+rdx*8+16]
+        sbb     r15, [rsi+rdx*8+24]
+        rcl     rbx, 1
+        add     rdx, 4
+        mov     [rbp+rcx*8], r12
+        mov     [rbp+rcx*8+8], r13
+        mov     [rbp+rcx*8+16], r14
+        mov     [rbp+rcx*8+24], r15
+        add     rcx, 4
+        jnc     .1
+        cmp     rcx, 2
+        jg      .5
+        jz      .4
+        jp      .3
+
+.2:     bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp]
+        mov     r12, r8
+        mov     r9, [rdi+rdx*8+8]
+        adc     r9, [rbp+8]
+        mov     r10, [rdi+rdx*8+16]
+        adc     r10, [rbp+16]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rdi]
+        mov     r13, r9
+        adc     r9, [rdi+8]
+        mov     r14, r10
+        adc     r10, [rdi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        adc     r13, [rbp+rdx*8+8]
+        adc     r14, [rbp+rdx*8+16]
+        rcl     rbx, 1
+        bt      rax, 1
+        sbb     r8, [rsi]
+        sbb     r9, [rsi+8]
+        sbb     r10, [rsi+16]
+        mov     [rdi+rdx*8+16], r10
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        mov     [rdi+rdx*8+8], r9
+        sbb     r12, [rsi+rdx*8]
+        sbb     r13, [rsi+rdx*8+8]
+        sbb     r14, [rsi+rdx*8+16]
+        rcl     rbx, 1
+        add     rdx, 3
+        mov     [rbp], r12
+        mov     [rbp+8], r13
+        mov     [rbp+16], r14
+        jmp     .5
+
+.3:     bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp+8]
+        mov     r12, r8
+        mov     r9, [rdi+rdx*8+8]
+        adc     r9, [rbp+16]
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rdi+8]
+        mov     r13, r9
+        adc     r9, [rdi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        adc     r13, [rbp+rdx*8+8]
+        rcl     rbx, 1
+        bt      rax, 1
+        sbb     r8, [rsi+8]
+        sbb     r9, [rsi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        mov     [rdi+rdx*8+8], r9
+        sbb     r12, [rsi+rdx*8]
+        sbb     r13, [rsi+rdx*8+8]
+        rcl     rbx, 1
+        add     rdx, 2
+        mov     [rbp+8], r12
+        mov     [rbp+16], r13
+        jmp     .5
+
+.4:     bt      rbx, 2
+        mov     r8, [rdi+rdx*8]
+        adc     r8, [rbp+16]
+        mov     r12, r8
+        rcl     rbx, 1
+        bt      rax, 1
+        adc     r8, [rdi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        adc     r12, [rbp+rdx*8]
+        rcl     rbx, 1
+        bt      rax, 1
+        sbb     r8, [rsi+16]
+        rcl     rax, 1
+        bt      rbx, 2
+        mov     [rdi+rdx*8], r8
+        sbb     r12, [rsi+rdx*8]
+        rcl     rbx, 1
+        add_one rdx
+        mov     [rbp+rcx*8], r12
+
+;       move low half rbx carry into rax
+.5:     rcr     rax, 3
+        bt      rbx, 2
+        rcl     rax, 3
+        mov     r8, [rsp]
+        mov     rcx, rsi
+        mov     rsi,[rsp+8]
+        lea     r9, [r8+r8]
+        lea     rsi, [rsi+r9*8]
+        lea     r11, [rbp+24]
+        sub     r11, rsi
+        sar     r11, 3
+        bt      r8, 0
+        jnc     .9
+
+;       if odd the do next two  
+        add     r11, 2
+        mov     r8, [rbp+rdx*8]
+        mov     r9, [rbp+rdx*8+8]
+        rcr     rbx, 2
+        adc     r8,0
+        adc     r9, 0
+        rcl     rbx, 1
+        sbb     r8, [rcx+rdx*8]
+        sbb     r9, [rcx+rdx*8+8]
+        rcr     rbx, 2
+        adc     [rbp+24], r8
+        adc     [rbp+32], r9
+        rcl     rbx, 3
+
+; Now add in any accummulated carries and/or borrows
+;
+; NOTE: We can't propagate individual borrows or carries from the second
+; and third quarter blocks into the fourth quater block by simply waiting
+; for carry (or borrow) propagation to end.  This is because a carry into
+; the fourth quarter block when it contains only maximum integers or a 
+; borrow when it contains all zero integers will incorrectly propagate
+; beyond the end of the top quarter block.
+
+.9:     lea     rdx, [rdi+rdx*8]
+        sub     rdx, rsi
+        sar     rdx, 3
+
+; carries/borrrow from second to third quarter quarter block
+;   rax{2} is the carry in (B + C)
+;   rax{1} is the carry in (B + C) + A
+;   rax{0} is the borrow in (B + C + A) - E
+
+        mov     rcx, rdx
+        bt      rax, 0
+.10:    sbb     qword[rsi+rcx*8], 0
+        add_one rcx
+        jrcxz   .11
+        jc      .10
+
+.11     mov     rcx, rdx
+        bt      rax, 1
+.12:    adc     qword[rsi+rcx*8], 0
+        add_one rcx
+        jrcxz   .13
+        jc      .12
+
+.13     mov     rcx, rdx
+        bt      rax, 2
+.14:    adc     qword[rsi+rcx*8], 0
+        add_one rcx
+        jrcxz   .15
+        jc      .14
+
+; carries/borrrow from third to fourth quarter quarter block
+;   rbx{2} is the carry in (B + C)
+;   rbx{1} is the carry in (B + C) + D
+;   rbx{0} is the borrow in (B + C + D) - F
+
+.15:    mov     rcx, r11
+        bt      rbx, 0
+.16:    sbb     qword[rsi+rcx*8], 0
+        add_one rcx
+        jrcxz   .17
+        jc      .16
+
+.17:    mov     rcx, r11
+        bt      rbx, 1
+.18:    adc     qword[rsi+rcx*8], 0
+        add_one rcx
+        jrcxz   .19
+        jc      .18
+
+.19:    mov     rcx, r11
+        bt      rbx, 2
+.20:    adc     qword[rsi+rcx*8], 0
+        add_one rcx
+        jrcxz   .21
+        jc      .20
+.21:
+        END_PROC reg_save_list
+
+        end

--- a/SMP/yasm/sandybridge/lshift.asm
+++ b/SMP/yasm/sandybridge/lshift.asm
@@ -1,0 +1,173 @@
+; PROLOGUE(mpn_lshift)
+
+;  Version 1.0.4.
+;
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_lshift(mp_ptr, mp_ptr, mp_size_t, mp_uint)
+;  rax                     rdi      rsi        rdx      rcx
+;  rax                     rcx      rdx         r8      r9d
+
+%include "yasm_mac.inc"
+
+    CPU  SSE4.2
+    BITS 64
+
+    LEAF_PROC mpn_lshift
+    mov     r10, rcx
+    mov     ecx, r9d
+    cmp     r8, 2
+    ja      .3
+    jz      .2
+.1:	mov     rdx, [rdx]
+    mov     rax, rdx
+    shl     rdx, cl
+    neg     rcx
+    shr     rax, cl
+    mov     [r10], rdx
+    ret
+
+.2:	mov     r8, [rdx]
+    mov     r9, [rdx+8]
+    mov     r11, r8
+    mov     rax, r9
+    shl     r8, cl
+    shl     r9, cl
+    neg     rcx
+    shr     r11, cl
+    shr     rax, cl
+    or      r9, r11
+    mov     [r10], r8
+    mov     [r10+8], r9
+    ret
+
+.3:	mov     eax, 64
+    sub     rax, rcx
+    movq    xmm0, rcx
+    movq    xmm1, rax
+    lea     r9, [rdx+r8*8-16]
+    mov     r11, r9
+    and     r9, -16
+    movdqa  xmm3, [r9]
+    movdqa  xmm5, xmm3
+    psrlq   xmm3, xmm1
+    pshufd  xmm3, xmm3, 0x4e
+    movq    rax, xmm3
+    cmp     r11, r9
+    je      .4
+    movq    xmm2, [rdx+r8*8-8]
+    movq    xmm4, xmm2
+    psrlq   xmm2, xmm1
+    movq    rax, xmm2
+    psllq   xmm4, xmm0
+    por     xmm4, xmm3
+    movq    [r10+r8*8-8], xmm4
+    dec     r8
+.4:	sub     r8, 5
+    jle     .6
+
+    xalign  16
+.5: movdqa  xmm2, [rdx+r8*8+8]
+    movdqa  xmm4, xmm2
+    psllq   xmm5, xmm0
+    psrlq   xmm2, xmm1
+    movhlps xmm3, xmm2
+    por     xmm5, xmm3
+    movq    [r10+r8*8+24], xmm5
+    pshufd  xmm2, xmm2, 0x4e
+    movhpd  [r10+r8*8+32], xmm5
+    movdqa  xmm3, [rdx+r8*8-8]
+    movdqa  xmm5, xmm3
+    psrlq   xmm3, xmm1
+    movhlps xmm2, xmm3
+    psllq   xmm4, xmm0
+    pshufd  xmm3, xmm3, 0x4e
+    por     xmm4, xmm2
+    movq    [r10+r8*8+8], xmm4
+    movhpd  [r10+r8*8+16], xmm4
+    sub     r8, 4
+    jg      .5
+.6: cmp     r8, -1
+    je      .9
+    jg      .8
+    jp      .10
+.7:	pxor    xmm2, xmm2
+    psllq   xmm5, xmm0
+    movhlps xmm3, xmm2
+    por     xmm5, xmm3
+    movq    [r10+r8*8+24], xmm5
+    movhpd  [r10+r8*8+32], xmm5
+    ret
+
+    xalign  16
+.8:	movdqa  xmm2, [rdx+r8*8+8]
+    movdqa  xmm4, xmm2
+    psllq   xmm5, xmm0
+    psrlq   xmm2, xmm1
+    movhlps xmm3, xmm2
+    por     xmm5, xmm3
+    movq    [r10+r8*8+24], xmm5
+    pshufd  xmm2, xmm2, 0x4e
+    movhpd  [r10+r8*8+32], xmm5
+    movq    xmm3, [rdx+r8*8]
+    pshufd  xmm3, xmm3, 0x4e
+    movdqa  xmm5, xmm3
+    psrlq   xmm3, xmm1
+    movhlps xmm2, xmm3
+    psllq   xmm4, xmm0
+    por     xmm4, xmm2
+    movq    [r10+r8*8+8], xmm4
+    movhpd  [r10+r8*8+16], xmm4
+    psllq   xmm5, xmm0
+    movhpd  [r10+r8*8], xmm5
+    ret
+
+    xalign  16
+.9:	movdqa  xmm2, [rdx+r8*8+8]
+    movdqa  xmm4, xmm2
+    psllq   xmm5, xmm0
+    psrlq   xmm2, xmm1
+    movhlps xmm3, xmm2
+    por     xmm5, xmm3
+    movq    [r10+r8*8+24], xmm5
+    pshufd  xmm2, xmm2, 0x4e
+    movhpd  [r10+r8*8+32], xmm5
+    pxor    xmm3, xmm3
+    movhlps xmm2, xmm3
+    psllq   xmm4, xmm0
+    por     xmm4, xmm2
+    movq    [r10+r8*8+8], xmm4
+    movhpd  [r10+r8*8+16], xmm4
+    ret
+
+    xalign  16
+.10:movq    xmm2, [rdx+r8*8+16]
+    pshufd  xmm2, xmm2, 0x4e
+    movdqa  xmm4, xmm2
+    psllq   xmm5, xmm0
+    psrlq   xmm2, xmm1
+    movhlps xmm3, xmm2
+    por     xmm5, xmm3
+    movq    [r10+r8*8+24], xmm5
+    movhpd  [r10+r8*8+32], xmm5
+    psllq   xmm4, xmm0
+    movhpd  [r10+r8*8+16], xmm4
+    ret
+
+    end

--- a/SMP/yasm/sandybridge/lshift1.asm
+++ b/SMP/yasm/sandybridge/lshift1.asm
@@ -1,0 +1,110 @@
+; PROLOGUE(mpn_lshift1)
+
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_lshift1(mp_ptr, mp_ptr, mp_size_t)
+;  rax                      rdi     rsi        rdx
+;  rax                      rcx     rdx         r8
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+    LEAF_PROC mpn_lshift1
+    mov     rax, r8
+	and     r8, 7
+	inc     r8
+	mov     [rsp+0x18], r8
+	shr     rax, 3
+	cmp     rax, 0
+	jz      .2
+	
+	xalign  16
+.1:	mov     r8, [rdx]
+	mov     r9, [rdx+8]
+	mov     r10, [rdx+16]
+	mov     r11, [rdx+24]
+	adc     r8, r8
+	adc     r9, r9
+	adc     r10, r10
+	adc     r11, r11
+	mov     [rcx], r8
+	mov     [rcx+8], r9
+	mov     [rcx+16], r10
+	mov     [rcx+24], r11
+	mov     r8, [rdx+32]
+	mov     r9, [rdx+40]
+	mov     r10, [rdx+48]
+	mov     r11, [rdx+56]
+	adc     r8, r8
+	adc     r9, r9
+	adc     r10, r10
+	adc     r11, r11
+	mov     [rcx+32], r8
+	mov     [rcx+40], r9
+	mov     [rcx+48], r10
+	mov     [rcx+56], r11
+	lea     rcx, [rcx+64]
+	dec     rax
+	lea     rdx, [rdx+64]
+	jnz     .1
+.2:	mov     rax, [rsp+0x18]
+	dec     rax
+	jz      .3
+;	Could still have cache-bank conflicts in this tail part
+	mov     r8, [rdx]
+	adc     r8, r8
+	mov     [rcx], r8
+	dec     rax
+	jz      .3
+	mov     r8, [rdx+8]
+	adc     r8, r8
+	mov     [rcx+8], r8
+	dec     rax
+	jz      .3
+	mov     r8, [rdx+16]
+	adc     r8, r8
+	mov     [rcx+16], r8
+	dec     rax
+	jz      .3
+	mov     r8, [rdx+24]
+	adc     r8, r8
+	mov     [rcx+24], r8
+	dec     rax
+	jz      .3
+	mov     r8, [rdx+32]
+	adc     r8, r8
+	mov     [rcx+32], r8
+	dec     rax
+	jz      .3
+	mov     r8, [rdx+40]
+	adc     r8, r8
+	mov     [rcx+40], r8
+	dec     rax
+	jz      .3
+	mov     r8, [rdx+48]
+	adc     r8, r8
+	mov     [rcx+48], r8
+.3:	sbb     rax, rax
+	neg     rax
+	ret
+
+	end

--- a/SMP/yasm/sandybridge/lshiftc.asm
+++ b/SMP/yasm/sandybridge/lshiftc.asm
@@ -1,0 +1,147 @@
+; PROLOGUE(mpn_lshiftc)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  void lshiftc(mp_ptr, mp_ptr, mp_size_t, mp_uint)
+;                  rdi     rsi        rdx      rcx
+;                  rcx     rdx         r8      r9d
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+    LEAF_PROC mpn_lshiftc
+	mov     r9d, r9d
+	movq    mm0, r9
+	mov     rax, 64
+	sub     rax, r9
+	pcmpeqb mm6, mm6
+	movq    mm1, rax
+	lea     rdx, [rdx+8]
+	lea     rcx, [rcx+8]
+	sub     r8, 5
+	movq    mm5, [rdx+r8*8+24]
+	movq    mm3, mm5
+	psrlq   mm5, mm1
+	movq    rax, mm5
+	psllq   mm3, mm0
+	jc      .2
+	
+	xalign  16
+.1: movq    mm2, [rdx+r8*8+16]
+	movq    mm4, mm2
+	psrlq   mm2, mm1
+	por     mm3, mm2
+	movq    mm2, [rdx+r8*8]
+	pxor    mm3, mm6
+	movq    [rcx+r8*8+24], mm3
+	psllq   mm4, mm0
+	movq    mm5, [rdx+r8*8+8]
+	movq    mm3, mm5
+	psrlq   mm5, mm1
+	por     mm4, mm5
+	pxor    mm4, mm6
+	movq    [rcx+r8*8+16], mm4
+	psllq   mm3, mm0
+	movq    mm4, mm2
+	movq    mm5, [rdx+r8*8-8]
+	sub     r8, 4
+	psrlq   mm2, mm1
+	por     mm3, mm2
+	pxor    mm3, mm6
+	movq    [rcx+r8*8+40], mm3
+	psllq   mm4, mm0
+	movq    mm3, mm5
+	psrlq   mm5, mm1
+	por     mm4, mm5
+	pxor    mm4, mm6
+	movq    [rcx+r8*8+32], mm4
+	psllq   mm3, mm0
+	jnc     .1
+.2: cmp     r8, -2
+	jz      .4
+	jp      .5
+	js      .6
+.3:	movq    mm2, [rdx+r8*8+16]
+	movq    mm4, mm2
+	psrlq   mm2, mm1
+	por     mm3, mm2
+	movq    mm2, [rdx+r8*8]
+	pxor    mm3, mm6
+	movq    [rcx+r8*8+24], mm3
+	psllq   mm4, mm0
+	movq    mm5, [rdx+r8*8+8]
+	movq    mm3, mm5
+	psrlq   mm5, mm1
+	por     mm4, mm5
+	pxor    mm4, mm6
+	movq    [rcx+r8*8+16], mm4
+	psllq   mm3, mm0
+	movq    mm4, mm2
+	psrlq   mm2, mm1
+	por     mm3, mm2
+	pxor    mm3, mm6
+	movq    [rcx+r8*8+8], mm3
+	psllq   mm4, mm0
+	pxor    mm4, mm6
+	movq    [rcx+r8*8], mm4
+	emms
+	ret
+
+	xalign  16
+.4:	movq    mm2, [rdx+r8*8+16]
+	movq    mm4, mm2
+	psrlq   mm2, mm1
+	por     mm3, mm2
+	pxor    mm3, mm6
+	movq    [rcx+r8*8+24], mm3
+	psllq   mm4, mm0
+	movq    mm5, [rdx+r8*8+8]
+	movq    mm3, mm5
+	psrlq   mm5, mm1
+	por     mm4, mm5
+	pxor    mm4, mm6
+	movq    [rcx+r8*8+16], mm4
+	psllq   mm3, mm0
+	pxor    mm3, mm6
+	movq    [rcx+r8*8+8], mm3
+	emms
+	ret
+
+	xalign  16
+.5:	movq    mm2, [rdx+r8*8+16]
+	movq    mm4, mm2
+	psrlq   mm2, mm1
+	por     mm3, mm2
+	pxor    mm3, mm6
+	movq    [rcx+r8*8+24], mm3
+	psllq   mm4, mm0
+	pxor    mm4, mm6
+	movq    [rcx+r8*8+16], mm4
+	emms
+	ret
+
+	xalign  16
+.6:	pxor    mm3, mm6
+	movq    [rcx+r8*8+24], mm3
+	emms
+	ret
+	

--- a/SMP/yasm/sandybridge/mod_1_1.asm
+++ b/SMP/yasm/sandybridge/mod_1_1.asm
@@ -1,0 +1,68 @@
+; PROLOGUE(mpn_mod_1_1)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_mod_1_1(mp_ptr, mp_ptr, mp_size_t, mp_ptr)
+;  rax                       rdi     rsi        rdx     rcx
+;  rax                       rcx     rdx         r8      r9
+
+%include 'yasm_mac.inc'
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi, r13
+
+    FRAME_PROC mpn_mod_1_1, 0, reg_save_list
+    mov     rsi, rdx
+    mov     rdx, r8
+    
+	mov     r13, [rsi+rdx*8-8]
+	mov     rax, [rsi+rdx*8-16]
+	mov     r8, [r9]
+	mov     r9, [r9+8]
+	mov     rdi, rdx
+	sub     rdi, 2
+	
+	xalign  16
+.1:	mov     r10, [rsi+rdi*8-8]
+	mul     r8
+	add     r10, rax
+	mov     r11, 0
+	adc     r11, rdx
+	mov     rax, r13
+	mul     r9
+	add     rax, r10
+	mov     r13, r11
+	adc     r13, rdx
+	dec     rdi
+	jnz     .1
+
+	mov     [rcx], rax
+	mov     rax, r8
+	mul     r13
+	add     [rcx], rax
+	adc     rdx, 0
+	mov     [rcx+8], rdx
+	END_PROC reg_save_list
+	
+	end

--- a/SMP/yasm/sandybridge/mod_1_2.asm
+++ b/SMP/yasm/sandybridge/mod_1_2.asm
@@ -1,0 +1,106 @@
+; PROLOGUE(mpn_mod_1_2)
+
+;  Copyright 2011 The Code Cavern  
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_mod_1_2(mp_ptr, mp_ptr, mp_size_t, mp_ptr)
+;  rax                       rdi     rsi        rdx     rcx
+;  rax                       rcx     rdx         r8      r9
+
+%include 'yasm_mac.inc'
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi, r12, r13, r14
+
+        FRAME_PROC mpn_mod_1_2, 0, reg_save_list
+        mov     rdi, rcx
+        mov     rsi, rdx
+        mov     rdx, r8
+
+        mov     r14, [rsi+rdx*8-8]
+        mov     r13, [rsi+rdx*8-16]
+        mov     r8, [r9]
+        mov     r10, [r9+16]
+        mov     r9, [r9+8]
+        mov     rcx, rdx
+        mov     rax, [rsi+rdx*8-24]
+        mul     r8
+        mov     r11, [rsi+rcx*8-32]
+        xor     r12, r12
+        sub     rcx, 6
+        jc      .2
+    
+        align   16
+.1:     add     r11, rax
+        adc     r12, rdx
+        mov     rax, r9
+        mul     r13
+        add     r11, rax
+        adc     r12, rdx
+        mov     r13, r11
+        mov     rax, r10
+        mul     r14
+        add     r13, rax
+        mov     rax, [rsi+rcx*8+8]
+        mov     r14, r12
+        adc     r14, rdx
+        mul     r8
+        mov     r12d, 0
+        mov     r11, [rsi+rcx*8+0]
+        sub     rcx, 2
+        jnc     .1
+.2:     add     r11, rax
+        adc     r12, rdx
+        mov     rax, r9
+        mul     r13
+        add     r11, rax
+        adc     r12, rdx
+        mov     r13, r11
+        mov     rax, r10
+        mul     r14
+        add     r13, rax
+        mov     r14, r12
+        adc     r14, rdx
+        cmp     rcx, -2
+        je      .4
+.3:     mov     r11, [rsi+rcx*8+8]
+        xor     r12, r12
+        mov     rax, r8
+        mul     r13
+        add     r11, rax
+        adc     r12, rdx
+        mov     r13, r11
+        mov     rax, r9
+        mul     r14
+        add     r13, rax
+        mov     r14, r12
+        adc     r14, rdx
+.4:     mov     rax, r8
+        mul     r14
+        add     r13, rax
+        adc     rdx, 0
+        mov     [rdi], r13
+        mov     [rdi+8], rdx
+    	END_PROC reg_save_list
+	
+	    end

--- a/SMP/yasm/sandybridge/mod_1_3.asm
+++ b/SMP/yasm/sandybridge/mod_1_3.asm
@@ -1,0 +1,193 @@
+; PROLOGUE(mpn_mod_1_3)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_mod_1_3(mp_ptr, mp_ptr, mp_size_t, mp_ptr)
+;  rax                       rdi     rsi        rdx     rcx
+;  rax                       rcx     rdx         r8      r9
+
+;	(rdi,2)= not fully reduced remainder of (rsi,rdx) / divisor , and top limb <d
+;	where (rcx,4)  contains B^i % divisor
+
+%include 'yasm_mac.inc'
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi, r12, r13, r14, r15
+
+    FRAME_PROC mpn_mod_1_3, 0, reg_save_list
+    mov     rsi, rdx
+    mov     rdi, r8
+	mov     r15, [rsi+rdi*8-8]
+	mov     r14, [rsi+rdi*8-16]
+	mov     rax, [rsi+rdi*8-32]
+	mov     r12, [rsi+rdi*8-40]
+	mov     r8, [r9]
+	mov     r10, [r9+16]
+	mov     r11, [r9+24]
+	mov     r9, [r9+8]
+	sub     rdi, 8
+	jc      .2
+	
+; // r15 r14 -8() -16()=rax -24()=r12
+	xalign  16
+.1:	mul     r8
+	add     r12, rax
+	mov     rax, [rsi+rdi*8+40]
+	mov     r13, 0
+	adc     r13, rdx
+	mul     r9
+	add     r12, rax
+	nop
+	adc     r13, rdx
+	mov     rax, r10
+	mul     r14
+	add     r12, rax
+	adc     r13, rdx
+	mov     r14, r12
+	mov     rax, r11
+	mul     r15
+	add     r14, rax
+	mov     r12, [rsi+rdi*8+0]
+	mov     r15, r13
+	mov     rax, [rsi+rdi*8+8]
+	adc     r15, rdx
+	sub     rdi, 3
+	jnc     .1
+
+; // we have loaded up the next two limbs
+; // but because they are out of order we can have to do 3 limbs min
+.2:	cmp     rdi, -2
+	jl      .5
+	je      .4
+
+	; //two more limbs is 4 limbs
+	; // r15 r14 40() 8+24()=rax 0+24()=r12
+.3:	mul     r8
+	add     r12, rax
+	mov     rax, [rsi+rdi*8+40]
+	mov     r13, 0
+	adc     r13, rdx
+	mul     r9
+	add     r12, rax
+	nop
+	adc     r13, rdx
+	mov     rax, r10
+	mul     r14
+	add     r12, rax
+	adc     r13, rdx
+	mov     r14, r12
+	mov     rax, r11
+	mul     r15
+	add     r14, rax
+	mov     r12, [rsi+rdi*8+8]
+	mov     r15, r13
+	mov     rax, [rsi+rdi*8+16]
+	adc     r15, rdx
+	; // r15 r14 rax r12
+	mov     r13, 0
+	mul     r8
+	add     r12, rax
+	adc     r13, rdx
+	mov     rax, r9
+	mul     r14
+	add     r12, rax
+	adc     r13, rdx
+	mov     rax, r10
+	mul     r15
+	add     r12, rax
+	adc     r13, rdx
+	; // r13 r12
+	mov     rax, r8
+	mul     r13
+	jmp     .6
+
+	; //two more limbs is 4 limbs
+	; // r15 r14 40() 8+24()=rax 0+24()=r12
+	xalign  16
+.4:	mul     r8
+	add     r12, rax
+	mov     rax, [rsi+rdi*8+40]
+	mov     r13, 0
+	adc     r13, rdx
+	mul     r9
+	add     r12, rax
+	nop
+	adc     r13, rdx
+	mov     rax, r10
+	mul     r14
+	add     r12, rax
+	adc     r13, rdx
+	mov     r14, r12
+	mov     rax, r11
+	mul     r15
+	add     r14, rax
+	mov     r12, [rsi+rdi*8+16]
+	mov     r15, r13
+	adc     r15, rdx
+	; // r15 r14 r12
+	mov     r13, 0
+	mov     rax, r8
+	mul     r14
+	add     r12, rax
+	adc     r13, rdx
+	mov     rax, r9
+	mul     r15
+	add     r12, rax
+	adc     r13, rdx
+	; // r13 r12
+	mov     rax, r8
+	mul     r13
+	jmp     .6
+	
+	; // one more is 3 limbs
+	; // r15 r14 40() 8+24()=rax 0+24()=r12 
+	xalign  16
+.5:	mul     r8
+	add     r12, rax
+	mov     rax, [rsi+rdi*8+40]
+	mov     r13, 0
+	adc     r13, rdx
+	mul     r9
+	add     r12, rax
+	nop
+	adc     r13, rdx
+	mov     rax, r10
+	mul     r14
+	add     r12, rax
+	adc     r13, rdx
+	mov     rax, r11
+	mul     r15
+	add     r12, rax
+	mov     r15, r13
+	adc     r15, rdx
+	mov     rax, r8
+	mul     r15
+.6:	add     r12, rax
+	adc     rdx, 0
+	mov     [rcx], r12
+	mov     [rcx+8], rdx
+    END_PROC reg_save_list
+    
+    end
+    

--- a/SMP/yasm/sandybridge/mul_1.asm
+++ b/SMP/yasm/sandybridge/mul_1.asm
@@ -1,0 +1,149 @@
+; PROLOGUE(mpn_mul_1)
+
+;  Copyright 2011 The Code Cavern  
+;
+;  Windows Conversion Copyright 2011 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_mul_1(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  mp_limb_t mpn_mul_1c(mp_ptr, mp_ptr, mp_size_t, mp_limb_t, mp_limb_t)
+;  rax                     rdi     rsi        rdx        rcx         r8
+;  rax                     rcx     rdx         r8         r9   [rsp+40]
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi, r12
+
+        LEAF_PROC mpn_mul_1
+        mov     rax, [rdx]
+        cmp     r8, 1
+        jne     .1
+        mul     r9
+        mov     [rcx], rax
+        mov     rax, rdx
+        ret
+
+.1:     FRAME_PROC ?mpn_sandybridge_mul, 0, reg_save_list
+        mov     r11, 5
+        lea     rsi, [rdx+r8*8-40]
+        lea     rdi, [rcx+r8*8-40]
+        mov     rcx, r9
+        sub     r11, r8
+        mul     rcx
+        db      0x26
+        mov     r8, rax
+        db      0x26
+        mov     rax, [rsi+r11*8+8]
+        db      0x26
+        mov     r9, rdx
+        db      0x26
+        cmp     r11, 0
+        db      0x26
+        mov     [rsp-8], r12
+        db      0x26
+        jge     .2
+.1:     xor     r10, r10
+        mul     rcx
+        mov     [rdi+r11*8], r8
+        add     r9, rax
+        adc     r10, rdx
+        mov     rax, [rsi+r11*8+16]
+        mul     rcx
+        mov     [rdi+r11*8+8], r9
+        add     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+r11*8+24]
+        xor     r8, r8
+        xor     r9, r9
+        mul     rcx
+        mov     [rdi+r11*8+16], r10
+        add     r12, rax
+        adc     r8, rdx
+        mov     rax, [rsi+r11*8+32]
+        mul     rcx
+        mov     [rdi+r11*8+24], r12
+        add     r8, rax
+        adc     r9, rdx
+        add     r11, 4
+        mov     rax, [rsi+r11*8+8]
+        jnc     .1
+.2:     xor     r10, r10
+        mul     rcx
+        mov     [rdi+r11*8], r8
+        add     r9, rax
+        adc     r10, rdx
+        cmp     r11, 2
+        ja      .5
+        jz      .4
+        jp      .3
+        mov     rax, [rsi+16]
+        mul     rcx
+        mov     [rdi+8], r9
+        add     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+24]
+        xor     r8, r8
+        xor     r9, r9
+        mul     rcx
+        mov     [rdi+16], r10
+        add     r12, rax
+        adc     r8, rdx
+        mov     rax, [rsi+32]
+        mul     rcx
+        mov     [rdi+24], r12
+        add     r8, rax
+        adc     r9, rdx
+        mov     [rdi+32], r8
+        mov     rax, r9
+        EXIT_PROC   reg_save_list
+
+.3:     mov     rax, [rsi+24]
+        mul     rcx
+        mov     [rdi+16], r9
+        add     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+32]
+        xor     r8, r8
+        mul     rcx
+        mov     [rdi+24], r10
+        add     r12, rax
+        adc     r8, rdx
+        mov     [rdi+32], r12
+        mov     rax, r8
+        EXIT_PROC   reg_save_list
+
+        align   16
+.4:     mov     rax, [rsi+32]
+        mul     rcx
+        mov     [rdi+24], r9
+        add     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     [rdi+32], r10
+        mov     rax, r12
+        EXIT_PROC   reg_save_list
+
+.5:     mov     [rdi+32], r9
+        mov     rax, r10
+        END_PROC   reg_save_list
+
+        end

--- a/SMP/yasm/sandybridge/mul_2.asm
+++ b/SMP/yasm/sandybridge/mul_2.asm
@@ -1,0 +1,147 @@
+; PROLOGUE(mpn_mul_2)
+;  X86_64 mpn_mul_2
+;
+;  Copyright 2010 Jason Moxham
+;
+;  Windows Conversion Copyright 2010 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_mul_2(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  rax                     rdi     rsi        rdx        rcx
+;  rax                     rcx     rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+%define reg_save_list rsi, rdi, rbx
+
+        CPU  nehalem
+        BITS 64
+
+    	FRAME_PROC mpn_mul_2, 0, reg_save_list
+        mov     rbx, 3
+        lea     rdi, [rcx+r8*8-24]
+        lea     rsi, [rdx+r8*8-24]
+        sub     rbx, r8
+        mov     r8, [r9+8]
+        mov     rcx, [r9]
+
+        mov     r11, 0
+        mov     r9, 0
+        mov     rax, [rsi+rbx*8]
+        mov     r10, 0
+        mul     rcx
+        add     r11, rax
+        mov     rax, [rsi+rbx*8]
+        mov     [rdi+rbx*8], r11
+        adc     r9, rdx
+        cmp     rbx, 0
+        jge     .2
+
+        align   16
+.1:     mul     r8
+        add     r9, rax
+        adc     r10, rdx
+        mov     rax, [rsi+rbx*8+8]
+        mov     r11, 0
+        mul     rcx
+        add     r9, rax
+        adc     r10, rdx
+        adc     r11, 0
+        mov     rax, [rsi+rbx*8+8]
+        mul     r8
+        add     r10, rax
+        mov     rax, [rsi+rbx*8+16]
+        adc     r11, rdx
+        mul     rcx
+        add     r10, rax
+        mov     [rdi+rbx*8+8], r9
+        adc     r11, rdx
+        mov     r9, 0
+        mov     rax, [rsi+rbx*8+16]
+        adc     r9, 0
+        mul     r8
+        add     r11, rax
+        mov     [rdi+rbx*8+16], r10
+        mov     rax, [rsi+rbx*8+24]
+        mov     r10, 0
+        adc     r9, rdx
+        mul     rcx
+        add     r11, rax
+        mov     rax, [rsi+rbx*8+24]
+        mov     [rdi+rbx*8+24], r11
+        adc     r9, rdx
+        adc     r10, 0
+        add     rbx, 3
+        jnc     .1
+.2:     cmp     rbx, 1
+        ja      .5
+        je      .4
+.3:     mul     r8
+        add     r9, rax
+        adc     r10, rdx
+        mov     rax, [rsi+rbx*8+8]
+        mov     r11, 0
+        mul     rcx
+        add     r9, rax
+        adc     r10, rdx
+        adc     r11, 0
+        mov     rax, [rsi+rbx*8+8]
+        mul     r8
+        add     r10, rax
+        mov     rax, [rsi+rbx*8+16]
+        adc     r11, rdx
+        mul     rcx
+        add     r10, rax
+        mov     [rdi+rbx*8+8], r9
+        adc     r11, rdx
+        mov     r9, 0
+        mov     rax, [rsi+rbx*8+16]
+        adc     r9, 0
+        mul     r8
+        add     r11, rax
+        mov     [rdi+rbx*8+16], r10
+        adc     r9, rdx
+        mov     [rdi+rbx*8+24], r11
+        mov     rax, r9
+        EXIT_PROC reg_save_list
+
+.4:     mul     r8
+        add     r9, rax
+        adc     r10, rdx
+        mov     rax, [rsi+rbx*8+8]
+        mov     r11, 0
+        mul     rcx
+        add     r9, rax
+        adc     r10, rdx
+        adc     r11, 0
+        mov     rax, [rsi+rbx*8+8]
+        mul     r8
+        add     r10, rax
+        adc     r11, rdx
+        mov     [rdi+rbx*8+8], r9
+        mov     [rdi+rbx*8+16], r10
+        mov     rax, r11
+        EXIT_PROC reg_save_list
+
+.5:     mul     r8
+        add     r9, rax
+        adc     r10, rdx
+        mov     [rdi+rbx*8+8], r9
+        mov     rax, r10
+        END_PROC reg_save_list
+        
+        end    
+        

--- a/SMP/yasm/sandybridge/mul_basecase.asm
+++ b/SMP/yasm/sandybridge/mul_basecase.asm
@@ -1,0 +1,912 @@
+; PROLOGUE(mpn_mul_basecase)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_mul_basecase(mp_ptr, mp_ptr, mp_size_t, mp_ptr, mp_size_t)
+;  rax                           rdi     rsi        rdx     rcx         r8
+;  rax                           rcx     rdx         r8      r9   [rsp+40] 
+
+%include "yasm_mac.inc"
+
+%macro addmul2lp 0
+    xalign  16
+%%1:mov     rax, [rsi+rbx*8]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+rbx*8+8]
+    adc     r10, rdx
+    mov     r11, 0
+    mul     rcx
+    add     [rdi+rbx*8], r12
+    adc     r9, rax
+    mov     r12, 0
+    adc     r10, rdx
+    mov     rax, [rsi+rbx*8+8]
+    adc     r11, 0
+    mul     r8
+    add     [rdi+rbx*8+8], r9
+    adc     r10, rax
+    adc     r11, rdx
+    mov     rax, [rsi+rbx*8+16]
+    mul     rcx
+    add     r10, rax
+    mov     rax, [rsi+rbx*8+16]
+    adc     r11, rdx
+    adc     r12, 0
+    mul     r8
+    add     [rdi+rbx*8+16], r10
+    mov     r9, 0
+    adc     r11, rax
+    mov     r10, 0
+    mov     rax, [rsi+rbx*8+24]
+    adc     r12, rdx
+    mov     r15, r15
+    mul     rcx
+    add     r11, rax
+    mov     rax, [rsi+rbx*8+24]
+    adc     r12, rdx
+    adc     r9, 0
+    mul     r8
+    add     [rdi+rbx*8+24], r11
+    adc     r12, rax
+    adc     r9, rdx
+    mov     rax, [rsi+rbx*8+32]
+    mul     rcx
+    add     r12, rax
+    adc     r9, rdx
+    adc     r10, 0
+    add     rbx, 4
+    jnc     %%1
+%endmacro
+
+%macro addmul2pro0 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r12, rax
+    mov     r9, rdx
+    mov     r10, 0
+    mov     r8, [r13+r15*8+8]
+%endmacro
+
+%macro addmul2epi0 0
+    mov     rbx, r14
+    mov     rax, [rsi+24]
+    mul     r8
+    add     [rdi+24], r12
+    adc     r9, rax
+    adc     r10, rdx
+    add     r15, 2
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+32], r9
+    lea     rdi, [rdi+16]
+    mov     [rdi+24], r10
+%endmacro
+
+%macro addmul2pro1 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r12, rax
+    mov     r10, 0
+    mov     r9, rdx
+    mov     r8, [r13+r15*8+8]
+%endmacro
+
+%macro addmul2epi1 0
+    mov     rax, [rsi+16]
+    lea     rdi, [rdi+16]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+24]
+    mov     r11, 0
+    adc     r10, rdx
+    mul     rcx
+    add     [rdi], r12
+    adc     r9, rax
+    adc     r10, rdx
+    adc     r11, 0
+    mov     rax, [rsi+24]
+    mul     r8
+    add     [rdi+8], r9
+    adc     r10, rax
+    adc     r11, rdx
+    add     r15, 2
+    mov     rbx, r14
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+24], r11
+    mov     [rdi+16], r10
+%endmacro
+
+%macro addmul2pro2 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r10, 0
+    mov     r12, rax
+    mov     r9, rdx
+    mov     r8, [r13+r15*8+8]
+%endmacro
+
+%macro addmul2epi2 0
+    mov     rax, [rsi+8]
+    lea     rdi, [rdi+16]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+16]
+    adc     r10, rdx
+    mov     r11, 0
+    mul     rcx
+    add     [rdi-8], r12
+    adc     r9, rax
+    mov     r12, 0
+    adc     r10, rdx
+    mov     rax, [rsi+16]
+    adc     r11, 0
+    mul     r8
+    add     [rdi], r9
+    adc     r10, rax
+    adc     r11, rdx
+    mov     rax, [rsi+24]
+    mul     rcx
+    add     r10, rax
+    mov     rax, [rsi+24]
+    adc     r11, rdx
+    adc     r12, 0
+    mul     r8
+    add     [rdi+8], r10
+    adc     r11, rax
+    adc     r12, rdx
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+16], r11
+    mov     [rdi+24], r12
+    add     r15, 2
+    mov     rbx, r14
+%endmacro
+
+%macro addmul2pro3 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r12, rax
+    mov     r9, rdx
+    mov     r8, [r13+r15*8+8]
+    mov     r10, 0
+%endmacro
+
+%macro addmul2epi3 0
+    mov     rax, [rsi]
+    lea     rdi, [rdi+16]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+8]
+    adc     r10, rdx
+    mov     r11, 0
+    mul     rcx
+    add     [rdi-16], r12
+    adc     r9, rax
+    mov     r12, 0
+    adc     r10, rdx
+    mov     rax, [rsi+8]
+    adc     r11, 0
+    mul     r8
+    add     [rdi-8], r9
+    adc     r10, rax
+    adc     r11, rdx
+    mov     rax, [rsi+16]
+    mul     rcx
+    add     r10, rax
+    mov     rax, [rsi+16]
+    adc     r11, rdx
+    adc     r12, 0
+    mul     r8
+    add     [rdi], r10
+    mov     r9, 0
+    adc     r11, rax
+    mov     r10, 0
+    mov     rax, [rsi+24]
+    adc     r12, rdx
+    mov     r15, r15
+    mul     rcx
+    add     r11, rax
+    mov     rax, [rsi+24]
+    adc     r12, rdx
+    adc     r9, 0
+    mul     r8
+    add     [rdi+8], r11
+    adc     r12, rax
+    adc     r9, rdx
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+16], r12
+    mov     [rdi+24], r9
+    add     r15, 2
+    mov     rbx, r14
+%endmacro
+
+%macro mul2lp 0
+    xalign  16
+%%1:mov     rax, [rsi+rbx*8]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+rbx*8+8]
+    adc     r10, rdx
+    mov     r11, 0
+    mul     rcx
+    mov     [rdi+rbx*8], r12
+    add     r9, rax
+    mov     r12, 0
+    adc     r10, rdx
+    mov     rax, [rsi+rbx*8+8]
+    adc     r11, 0
+    mul     r8
+    mov     [rdi+rbx*8+8], r9
+    add     r10, rax
+    adc     r11, rdx
+    mov     rax, [rsi+rbx*8+16]
+    mul     rcx
+    add     r10, rax
+    mov     rax, [rsi+rbx*8+16]
+    adc     r11, rdx
+    adc     r12, 0
+    mul     r8
+    mov     [rdi+rbx*8+16], r10
+    mov     r9, 0
+    add     r11, rax
+    mov     r10, 0
+    mov     rax, [rsi+rbx*8+24]
+    adc     r12, rdx
+    mov     r15, r15
+    mul     rcx
+    add     r11, rax
+    mov     rax, [rsi+rbx*8+24]
+    adc     r12, rdx
+    adc     r9, 0
+    mul     r8
+    mov     [rdi+rbx*8+24], r11
+    add     r12, rax
+    adc     r9, rdx
+    mov     rax, [rsi+rbx*8+32]
+    mul     rcx
+    add     r12, rax
+    adc     r9, rdx
+    adc     r10, 0
+    add     rbx, 4
+    jnc     %%1
+%endmacro
+
+%macro mul2pro0 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r12, rax
+    mov     r9, rdx
+    mov     r10, 0
+    mov     r8, [r13+r15*8+8]
+%endmacro
+
+%macro mul2epi0 0
+    mov     rbx, r14
+    mov     rax, [rsi+24]
+    mul     r8
+    mov     [rdi+24], r12
+    add     r9, rax
+    adc     r10, rdx
+    add     r15, 2
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+32], r9
+    lea     rdi, [rdi+16]
+    mov     [rdi+24], r10
+%endmacro
+
+%macro mul2pro1 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r12, rax
+    mov     r10, 0
+    mov     r9, rdx
+    mov     r8, [r13+r15*8+8]
+%endmacro
+
+%macro mul2epi1 0
+    mov     rax, [rsi+16]
+    lea     rdi, [rdi+16]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+24]
+    mov     r11, 0
+    adc     r10, rdx
+    mul     rcx
+    mov     [rdi], r12
+    add     r9, rax
+    adc     r10, rdx
+    adc     r11, 0
+    mov     rax, [rsi+24]
+    mul     r8
+    mov     [rdi+8], r9
+    add     r10, rax
+    adc     r11, rdx
+    add     r15, 2
+    mov     rbx, r14
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+24], r11
+    mov     [rdi+16], r10
+%endmacro
+
+%macro mul2pro2 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r10, 0
+    mov     r12, rax
+    mov     r9, rdx
+    mov     r8, [r13+r15*8+8]
+%endmacro
+
+%macro mul2epi2 0
+    mov     rax, [rsi+8]
+    lea     rdi, [rdi+16]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+16]
+    adc     r10, rdx
+    mov     r11, 0
+    mul     rcx
+    mov     [rdi-8], r12
+    add     r9, rax
+    mov     r12, 0
+    adc     r10, rdx
+    mov     rax, [rsi+16]
+    adc     r11, 0
+    mul     r8
+    mov     [rdi], r9
+    add     r10, rax
+    adc     r11, rdx
+    mov     rax, [rsi+24]
+    mul     rcx
+    add     r10, rax
+    mov     rax, [rsi+24]
+    adc     r11, rdx
+    adc     r12, 0
+    mul     r8
+    mov     [rdi+8], r10
+    add     r11, rax
+    adc     r12, rdx
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+16], r11
+    mov     [rdi+24], r12
+    add     r15, 2
+    mov     rbx, r14
+%endmacro
+
+%macro mul2pro3 0
+    mov     rcx, [r13+r15*8]
+    mul     rcx
+    mov     r12, rax
+    mov     r9, rdx
+    mov     r8, [r13+r15*8+8]
+    mov     r10, 0
+%endmacro
+
+%macro mul2epi3 0
+    mov     rax, [rsi]
+    lea     rdi, [rdi+16]
+    mul     r8
+    add     r9, rax
+    mov     rax, [rsi+8]
+    adc     r10, rdx
+    mov     r11, 0
+    mul     rcx
+    mov     [rdi-16], r12
+    add     r9, rax
+    mov     r12, 0
+    adc     r10, rdx
+    mov     rax, [rsi+8]
+    adc     r11, 0
+    mul     r8
+    mov     [rdi-8], r9
+    add     r10, rax
+    adc     r11, rdx
+    mov     rax, [rsi+16]
+    mul     rcx
+    add     r10, rax
+    mov     rax, [rsi+16]
+    adc     r11, rdx
+    adc     r12, 0
+    mul     r8
+    mov     [rdi], r10
+    mov     r9, 0
+    add     r11, rax
+    mov     r10, 0
+    mov     rax, [rsi+24]
+    adc     r12, rdx
+    mov     r15, r15
+    mul     rcx
+    add     r11, rax
+    mov     rax, [rsi+24]
+    adc     r12, rdx
+    adc     r9, 0
+    mul     r8
+    mov     [rdi+8], r11
+    add     r12, rax
+    adc     r9, rdx
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+16], r12
+    mov     [rdi+24], r9
+    add     r15, 2
+    mov     rbx, r14
+%endmacro
+
+%macro mul1lp 0
+    xalign  16
+%%1:
+    mov     r10, 0
+    mul     r8
+    mov     [rdi+rbx*8-8], r12
+    add     r9, rax
+    db      0x26
+    adc     r10, rdx
+    mov     rax, [rsi+rbx*8+8]
+    mul     r8
+    mov     [rdi+rbx*8], r9
+    add     r10, rax
+    mov     r11d, 0
+    adc     r11, rdx
+    mov     rax, [rsi+rbx*8+16]
+    mov     r12, 0
+    mov     r9, 0
+    mul     r8
+    mov     [rdi+rbx*8+8], r10
+    db      0x26
+    add     r11, rax
+    db      0x26
+    adc     r12, rdx
+    mov     rax, [rsi+rbx*8+24]
+    mul     r8
+    mov     [rdi+rbx*8+16], r11
+    db      0x26
+    add     r12, rax
+    db      0x26
+    adc     r9, rdx
+    add     rbx, 4
+    mov     rax, [rsi+rbx*8]
+    jnc     %%1
+%endmacro
+
+; rbx is 0
+%macro mulnext0 0
+    mov     rax, [rsi+8]
+    mul     r8
+    mov     [rdi], r9
+    add     r10, rax
+    mov     r11d, 0
+    adc     r11, rdx
+    mov     rax, [rsi+16]
+    mov     r12d, 0
+    mul     r8
+    mov     [rdi+8], r10
+    add     r11, rax
+    adc     r12, rdx
+    mov     rax, [rsi+24]
+    mul     r8
+    mov     [rdi+16], r11
+    add     r12, rax
+    adc     rdx, 0
+    mov     [rdi+24], r12
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+32], rdx
+    inc     r15
+    lea     rdi, [rdi+8]
+    mov     rbx, r14
+%endmacro
+
+; rbx is 1
+%macro mulnext1 0
+    mov     rax, [rsi+16]
+    mul     r8
+    mov     [rdi+8], r9
+    add     r10, rax
+    mov     r12d, 0
+    adc     r12, rdx
+    mov     rax, [rsi+24]
+    mul     r8
+    mov     [rdi+16], r10
+    add     r12, rax
+    adc     rdx, 0
+    mov     [rdi+24], r12
+    mov     [rdi+32], rdx
+    inc     r15
+    lea     rdi, [rdi+8]
+    mov     rbx, r14
+    mov     rax, [rsi+r14*8]
+%endmacro
+
+; rbx is 2
+%macro mulnext2 0
+    mov     rax, [rsi+24]
+    mul     r8
+    mov     [rdi+16], r9
+    add     r10, rax
+    mov     r11d, 0
+    adc     r11, rdx
+    mov     [rdi+24], r10
+    mov     [rdi+32], r11
+    inc     r15
+    lea     rdi, [rdi+8]
+    mov     rax, [rsi+r14*8]
+    mov     rbx, r14
+%endmacro
+
+; rbx is 3
+%macro mulnext3 0
+    mov     [rdi+24], r9
+    mov     [rdi+32], r10
+    inc     r15
+    lea     rdi, [rdi+8]
+    mov     rax, [rsi+r14*8]
+    mov     rbx, r14
+%endmacro
+
+%macro mpn_addmul_2_int 1
+    jz      %%2
+    xalign  16
+%%1:addmul2pro%1
+    addmul2lp
+    addmul2epi%1
+    jnz     %%1
+%%2:
+%endmacro
+
+%macro oldmulnext0 0
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    mov     [rdi+r11*8+8], r9
+    add     r10, rax
+    mov     ebx, 0
+    adc     rbx, rdx
+    mov     rax, [rsi+r11*8+24]
+    mov     r12d, 0
+    mul     r13
+    mov     [rdi+r11*8+16], r10
+    add     rbx, rax
+    adc     r12, rdx
+    mov     rax, [rsi+r11*8+32]
+    mul     r13
+    mov     [rdi+r11*8+24], rbx
+    add     r12, rax
+    adc     rdx, 0
+    mov     [rdi+r11*8+32], r12
+    mov     rax, [rsi+r14*8]
+    mov     [rdi+r11*8+40], rdx
+    inc     r8
+    mov     r11, r14
+%endmacro
+
+%macro oldmulnext1 0
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    mov     [rdi+r11*8+8], r9
+    add     r10, rax
+    mov     r12d, 0
+    adc     r12, rdx
+    mov     rax, [rsi+r11*8+24]
+    mul     r13
+    mov     [rdi+r11*8+16], r10
+    add     r12, rax
+    adc     rdx, 0
+    mov     [rdi+r11*8+24], r12
+    mov     [rdi+r11*8+32], rdx
+    inc     r8
+    lea     rdi, [rdi+8]
+    mov     r11, r14
+    mov     rax, [rsi+r14*8]
+%endmacro
+
+%macro oldmulnext2 0
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    mov     [rdi+r11*8+8], r9
+    add     r10, rax
+    mov     ebx, 0
+    adc     rbx, rdx
+    mov     [rdi+r11*8+16], r10
+    mov     [rdi+r11*8+24], rbx
+    inc     r8
+    mov     rax, [rsi+r14*8]
+    mov     r11, r14
+%endmacro
+
+%macro oldmulnext3 0
+    mov     [rdi+r11*8+8], r9
+    mov     [rdi+r11*8+16], r10
+    inc     r8
+    mov     rax, [rsi+r14*8]
+    mov     r11, r14
+%endmacro
+
+%macro oldaddmulpro0 0
+    mov     r13, [rcx+r8*8]
+    db      0x26
+    mul     r13
+    db      0x26
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    db      0x26
+    mov     r9, rdx
+    lea     rdi, [rdi+8]
+%endmacro
+
+%macro oldaddmulnext0 0
+    mov     r10d, 0
+    mul     r13
+    add     [rdi], r12
+    adc     r9, rax
+    adc     r10, rdx
+    mov     rax, [rsi+16]
+    mul     r13
+    add     [rdi+8], r9
+    adc     r10, rax
+    mov     ebx, 0
+    adc     rbx, rdx
+    mov     rax, [rsi+24]
+    mov     r12d, 0
+    mov     r11, r14
+    mul     r13
+    add     [rdi+16], r10
+    adc     rbx, rax
+    adc     r12, rdx
+    mov     rax, [rsi+32]
+    mul     r13
+    add     [rdi+24], rbx
+    adc     r12, rax
+    adc     rdx, 0
+    add     [rdi+32], r12
+    mov     rax, [rsi+r14*8]
+    adc     rdx, 0
+    inc     r8
+    mov     [rdi+40], rdx
+%endmacro
+
+%macro oldaddmulpro1 0
+    mov     r13, [rcx+r8*8]
+    mul     r13
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+%endmacro
+
+%macro oldaddmulnext1 0
+    mov     r10d, 0
+    mul     r13
+    add     [rdi+8], r12
+    adc     r9, rax
+    adc     r10, rdx
+    mov     rax, [rsi+24]
+    mul     r13
+    lea     rdi, [rdi+8]
+    add     [rdi+8], r9
+    adc     r10, rax
+    mov     r12d, 0
+    mov     rax, [rsi+32]
+    adc     r12, rdx
+    mov     r11, r14
+    mul     r13
+    add     [rdi+16], r10
+    adc     r12, rax
+    adc     rdx, 0
+    add     [rdi+24], r12
+    adc     rdx, 0
+    mov     [rdi+32], rdx
+    inc     r8
+    mov     rax, [rsi+r14*8]
+%endmacro
+
+%macro oldaddmulpro2 0
+    mov     r13, [rcx+r8*8]
+    lea     rdi, [rdi+8]
+    mul     r13
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+%endmacro
+
+%macro oldaddmulnext2 0
+    mov     r10d, 0
+    mul     r13
+    add     [rdi+r11*8], r12
+    adc     r9, rax
+    adc     r10, rdx
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    mov     ebx, 0
+    add     [rdi+r11*8+8], r9
+    adc     r10, rax
+    adc     rbx, rdx
+    mov     rax, [rsi+r14*8]
+    add     [rdi+r11*8+16], r10
+    adc     rbx, 0
+    mov     [rdi+r11*8+24], rbx
+    inc     r8
+    mov     r11, r14
+%endmacro
+
+%macro oldaddmulpro3 0
+    mov     r13, [rcx+r8*8]
+    db      0x26
+    mul     r13
+    db      0x26
+    mov     r12, rax
+    db      0x26
+    lea     rdi, [rdi+8]
+    db      0x26
+    mov     r9, rdx
+    mov     rax, [rsi+r14*8+8]
+%endmacro
+
+%macro oldaddmulnext3 0
+    mov     r11, r14
+    mul     r13
+    add     [rdi+24], r12
+    adc     r9, rax
+    adc     rdx, 0
+    add     [rdi+32], r9
+    mov     rax, [rsi+r14*8]
+    adc     rdx, 0
+    inc     r8
+    mov     [rdi+40], rdx
+%endmacro
+
+%macro oldmpn_muladdmul_1_int 1
+    oldmulnext%1
+    jz      %%2
+    xalign  16
+%%1:oldaddmulpro%1
+    oldaddmulnext%1
+    jnz     %%1
+%%2:
+%endmacro
+
+    CPU  Core2
+    BITS 64
+
+;  mp_limb_t mpn_mul_basecase(mp_ptr, mp_ptr, mp_size_t, mp_ptr, mp_size_t)
+;  rax                           rdi     rsi        rdx     rcx         r8
+;  rax                           rcx     rdx         r8      r9   [rsp+40] 
+
+%define reg_save_list   rbx, rsi, rdi, r12, r13, r14
+
+    LEAF_PROC mpn_mul_basecase
+    ; the current mul does not handle case one
+    cmp     r8d, 4
+    jg      fiveormore
+    cmp     r8d, 1
+    je      one
+
+    WIN64_GCC_PROC mpn_sandybridge_mbc1, 5, frame
+
+    mov     r14, 5
+    sub     r14, rdx
+    lea     rdi, [rdi+rdx*8-40]
+    lea     rcx, [rcx+r8*8]
+    neg     r8
+    lea     rsi, [rsi+rdx*8-40]
+    mov     rax, [rsi+r14*8]
+    mov     r13, [rcx+r8*8]
+    mov     r11, r14
+    mul     r13
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+    mov     r10d, 0
+    mul     r13
+    mov     [rdi+r11*8], r12
+    add     r9, rax
+    adc     r10, rdx
+    cmp     r11, 2
+    ja      .4
+    jz      .3
+    jp      .2
+.1:	oldmpn_muladdmul_1_int 0
+    jmp     .5
+.2:	oldmpn_muladdmul_1_int 1
+    jmp     .5
+.3:	oldmpn_muladdmul_1_int 2
+    jmp     .5
+.4:	oldmpn_muladdmul_1_int 3
+.5:	WIN64_GCC_END frame
+
+; rdx >= 5  as we dont have an inner jump
+; (rdi,rdx+r8)=(rsi,rdx)*(rcx,r8)
+
+%undef  reg_save_list
+%define reg_save_list   rbx, rsi, rdi, r12, r13, r14, r15
+
+    xalign  16
+fiveormore:
+    WIN64_GCC_PROC mpn_sandybridge_mbc2, 5, frame
+    movsxd  rdx, edx
+    movsxd  r8, r8d
+
+    mov     r14, 4
+    sub     r14, rdx
+    lea     rdi, [rdi+rdx*8-32]
+    lea     rsi, [rsi+rdx*8-32]
+    mov     r13, rcx
+    mov     r15, r8
+    lea     r13, [r13+r15*8]
+    neg     r15
+    mov     rbx, r14
+    mov     rax, [rsi+r14*8]
+    bt      r15, 0
+    jnc     .12
+.6:	inc     rbx
+    mov     r8, [r13+r15*8]
+    mul     r8
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+    cmp     rbx, 0
+    jge     .7
+    mul1lp
+.7:	mov     r10d, 0
+    mul     r8
+    mov     [rdi+rbx*8-8], r12
+    add     r9, rax
+    adc     r10, rdx
+    cmp     rbx, 2
+    ja      .11
+    jz      .10
+    jp      .9
+.8:	mulnext0
+    jmp     .20
+.9:	mulnext1
+    jmp     .14
+.10:mulnext2
+    jmp     .16
+.11:mulnext3
+    jmp     .18
+     ; as all the mul2pro? are the same
+.12:mul2pro0
+    mul2lp
+    cmp     rbx, 2
+    ja      .19
+    jz      .17
+    jp      .15
+.13:mul2epi3
+.14:mpn_addmul_2_int 3
+    WIN64_GCC_EXIT frame
+
+.15:mul2epi2
+.16:mpn_addmul_2_int 2
+    WIN64_GCC_EXIT frame
+
+.17:mul2epi1
+.18:mpn_addmul_2_int 1
+    WIN64_GCC_EXIT frame
+
+.19:mul2epi0
+.20:mpn_addmul_2_int 0
+
+    xalign  16
+.21:WIN64_GCC_END frame
+
+    xalign  16
+one:mov     rax, [rdx]
+    mul     qword [r9]
+    mov     [rcx], rax
+    mov     [rcx+8], rdx
+    ret
+    
+    end

--- a/SMP/yasm/sandybridge/nand_n.asm
+++ b/SMP/yasm/sandybridge/nand_n.asm
@@ -1,0 +1,86 @@
+; PROLOGUE(mpn_nand_n)
+
+;  mpn_nand_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_nand_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                     rcx        rdx         r8         r9
+;                     rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_nand_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	pcmpeqb xmm4, xmm4
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm1, [r8+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	add     r10, 4
+	movdqu  xmm3, [rdx+r10*8+16-32]
+	pand    xmm1, xmm3
+	pand    xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8-32], xmm0
+	pxor    xmm1, xmm4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [r8+r10*8]
+	mov     rax, [r8+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	mov     r9, [rdx+r10*8+16]
+	and     rax, r9
+	pand    xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	not     rax
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm2, [rdx+r10*8]
+	pand    xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	ret
+
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	and     rax, r9
+	not     rax
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/nior_n.asm
+++ b/SMP/yasm/sandybridge/nior_n.asm
@@ -1,0 +1,86 @@
+; PROLOGUE(mpn_nior_n)
+
+;  mpn_nior_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_nior_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                     rcx        rdx         r8         r9
+;                     rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_nior_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	pcmpeqb xmm4, xmm4
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm1, [r8+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	add     r10, 4
+	movdqu  xmm3, [rdx+r10*8+16-32]
+	por     xmm1, xmm3
+	por     xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8-32], xmm0
+	pxor    xmm1, xmm4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [r8+r10*8]
+	mov     rax, [r8+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	mov     r9, [rdx+r10*8+16]
+	or      rax, r9
+	por     xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	not     rax
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm2, [rdx+r10*8]
+	por     xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	ret
+
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	or      rax, r9
+	not     rax
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/popcount.asm
+++ b/SMP/yasm/sandybridge/popcount.asm
@@ -1,0 +1,70 @@
+; PROLOGUE(mpn_popcount)
+
+;  AMD64 mpn_popcount
+;  Copyright 2009 Jason Moxham
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;	mpn_limb_t mpn_popcount(mp_ptr,mp_size_t)
+;	rax                        rdi,      rsi
+;	eax                        rcx,      rdx
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_popcount
+	mov     r8, 5
+	lea     rcx, [rcx+rdx*8-40]
+	xor     eax, eax
+	sub     r8, rdx
+	jnc     .1
+	xalign  16
+.0:
+	popcnt  r9, [rcx+r8*8]
+	popcnt  r10, [rcx+r8*8+8]
+	popcnt  r11, [rcx+r8*8+16]
+	popcnt  rdx, [rcx+r8*8+24]
+	add     rax, r9
+	add     rax, rdx
+	add     rax, r10
+	popcnt  r9, [rcx+r8*8+32]
+	popcnt  r10, [rcx+r8*8+40]
+	add     rax, r9
+	add     rax, r11
+	add     rax, r10
+	add     r8, 6
+	jnc     .0
+.1:
+	lea     rdx, [rel .2]
+	lea     r8, [r8+r8*8]
+	add     rdx, r8
+	jmp     rdx
+.2:
+	nop
+	popcnt  r9, [rcx]
+	add     rax, r9
+.3:
+	popcnt  r10, [rcx+8]
+	add     rax, r10
+.4:	popcnt  r11, [rcx+16]
+	add     rax, r11
+.5:	popcnt  rdx, [rcx+24]
+	add     rax, rdx
+.6:	popcnt  r9, [rcx+32]
+	add     rax, r9
+.7:	ret
+
+    end

--- a/SMP/yasm/sandybridge/redc_1.asm
+++ b/SMP/yasm/sandybridge/redc_1.asm
@@ -1,0 +1,442 @@
+; PROLOGUE(mpn_redc_1)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  void mpn_redc_1(mp_ptr, mp_ptr, mp_srcptr, mp_size_t, mp_limb_t)
+;  rax                rdi     rsi        rdx        rcx        r8
+;  rax                rcx     rdx         r8         r9  [rsp+40]
+
+%include "yasm_mac.inc"
+
+%define reg_save_list   rbx, rsi, rdi, rbp, r12, r13, r14, r15
+
+    CPU  Core2
+    BITS 64
+
+%macro mpn_add 0
+
+    mov     rax, rcx
+    and     rax, 3
+    shr     rcx, 2
+    cmp     rcx, 0
+    jnz     %%1
+    mov     r11, [rsi]
+    add     r11, [rdx]
+    mov     [rdi], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+8]
+    adc     r11, [rdx+8]
+    mov     [rdi+8], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+16]
+    adc     r11, [rdx+16]
+    mov     [rdi+16], r11
+    jmp     %%2
+
+    xalign  16
+%%1:mov     r11, [rsi]
+    mov     r8, [rsi+8]
+    lea     rsi, [rsi+32]
+    adc     r11, [rdx]
+    adc     r8, [rdx+8]
+    lea     rdx, [rdx+32]
+    mov     [rdi], r11
+    mov     [rdi+8], r8
+    lea     rdi, [rdi+32]
+    mov     r9, [rsi-16]
+    mov     r10, [rsi-8]
+    adc     r9, [rdx-16]
+    adc     r10, [rdx-8]
+    mov     [rdi-16], r9
+    dec     rcx
+    mov     [rdi-8], r10
+    jnz     %%1
+    inc     rax
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi]
+    adc     r11, [rdx]
+    mov     [rdi], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+8]
+    adc     r11, [rdx+8]
+    mov     [rdi+8], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+16]
+    adc     r11, [rdx+16]
+    mov     [rdi+16], r11
+%%2:
+
+%endmacro
+
+%macro mpn_sub 0
+
+    mov     rax, rbp
+    and     rax, 3
+    shr     rbp, 2
+    cmp     rbp, 0
+    jnz     %%1
+    mov     r11, [rsi]
+    sub     r11, [rdx]
+    mov     [rbx], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+8]
+    sbb     r11, [rdx+8]
+    mov     [rbx+8], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+16]
+    sbb     r11, [rdx+16]
+    mov     [rbx+16], r11
+    jmp     %%2
+    xalign  16
+%%1:mov     r11, [rsi]
+    mov     r8, [rsi+8]
+    lea     rsi, [rsi+32]
+    sbb     r11, [rdx]
+    sbb     r8, [rdx+8]
+    lea     rdx, [rdx+32]
+    mov     [rbx], r11
+    mov     [rbx+8], r8
+    lea     rbx, [rbx+32]
+    mov     r9, [rsi-16]
+    mov     r10, [rsi-8]
+    sbb     r9, [rdx-16]
+    sbb     r10, [rdx-8]
+    mov     [rbx-16], r9
+    dec     rbp
+    mov     [rbx-8], r10
+    jnz     %%1
+    inc     rax
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi]
+    sbb     r11, [rdx]
+    mov     [rbx], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+8]
+    sbb     r11, [rdx+8]
+    mov     [rbx+8], r11
+    dec     rax
+    jz      %%2
+    mov     r11, [rsi+16]
+    sbb     r11, [rdx+16]
+    mov     [rbx+16], r11
+%%2:
+
+%endmacro
+
+%macro addmulloop 1
+
+    xalign  16
+%%1:mov     r10, 0
+    mul     r13
+    add     [r8+r11*8], r12
+    adc     r9, rax
+    db      0x26
+    adc     r10, rdx
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    add     [r8+r11*8+8], r9
+    adc     r10, rax
+    mov     ebx, 0
+    adc     rbx, rdx
+    mov     rax, [rsi+r11*8+24]
+    mov     r12, 0
+    mov     r9, 0
+    mul     r13
+    add     [r8+r11*8+16], r10
+    db      0x26
+    adc     rbx, rax
+    db      0x26
+    adc     r12, rdx
+    mov     rax, [rsi+r11*8+32]
+    mul     r13
+    add     [r8+r11*8+24], rbx
+    db      0x26
+    adc     r12, rax
+    db      0x26
+    adc     r9, rdx
+    add     r11, 4
+    mov     rax, [rsi+r11*8+8]
+    jnc     %%1
+
+%endmacro
+
+%macro addmulpropro0 0
+
+    imul    r13, rcx
+    lea     r8, [r8-8]
+
+%endmacro
+
+%macro addmulpro0 0
+
+    mov     r11, r14
+    lea     r8, [r8+8]
+    mov     rax, [rsi+r14*8]
+    mul     r13
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+    cmp     r14, 0
+
+%endmacro
+
+%macro addmulnext0 0
+
+    mov     r10d, 0
+    mul     r13
+    add     [r8+r11*8], r12
+    adc     r9, rax
+    adc     r10, rdx
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    add     [r8+r11*8+8], r9
+    adc     r10, rax
+    mov     ebx, 0
+    adc     rbx, rdx
+    mov     rax, [rsi+r11*8+24]
+    mov     r12d, 0
+    mov     r9d, 0
+    mul     r13
+    add     [r8+r11*8+16], r10
+    adc     rbx, rax
+    adc     r12, rdx
+    mov     rax, [rsi+r11*8+32]
+    mul     r13
+    add     [r8+r11*8+24], rbx
+    mov     r13, [r8+r14*8+8]
+    adc     r12, rax
+    adc     r9, rdx
+    imul    r13, rcx
+    add     [r8+r11*8+32], r12
+    adc     r9, 0
+    sub     r15, 1          ; ***
+    mov     [r8+r14*8], r9
+
+%endmacro
+
+%macro addmulpropro1 0
+
+%endmacro
+
+%macro addmulpro1 0
+
+    imul    r13, rcx
+    mov     rax, [rsi+r14*8]
+    mov     r11, r14
+    mul     r13
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+    cmp     r14, 0
+
+%endmacro
+
+%macro addmulnext1 0
+
+    mov     r10d, 0
+    mul     r13
+    add     [r8+r11*8], r12
+    adc     r9, rax
+    adc     r10, rdx
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    add     [r8+r11*8+8], r9
+    adc     r10, rax
+    mov     ebx, 0
+    adc     rbx, rdx
+    mov     rax, [rsi+r11*8+24]
+    mov     r12d, 0
+    mul     r13
+    add     [r8+r11*8+16], r10
+    adc     rbx, rax
+    adc     r12, rdx
+    add     [r8+r11*8+24], rbx
+    mov     r13, [r8+r14*8+8]
+    adc     r12, 0
+    sub     r15, 1          ; ***
+    mov     [r8+r14*8], r12
+    lea     r8, [r8+8]
+
+%endmacro
+
+%macro addmulpropro2 0
+
+%endmacro
+
+%macro addmulpro2 0
+
+    imul    r13, rcx
+    mov     rax, [rsi+r14*8]
+    mov     r11, r14
+    mul     r13
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+    cmp     r14, 0
+
+%endmacro
+
+%macro addmulnext2 0
+
+    mul     r13
+    add     [r8+r11*8], r12
+    adc     r9, rax
+    mov     r10d, 0
+    adc     r10, rdx
+    mov     rax, [rsi+r11*8+16]
+    mul     r13
+    add     [r8+r11*8+8], r9
+    adc     r10, rax
+    mov     ebx, 0
+    adc     rbx, rdx
+    mov     r13, [r8+r14*8+8]
+    add     [r8+r11*8+16], r10
+    adc     rbx, 0
+    mov     [r8+r14*8], rbx
+    sub     r15, 1          ; ***
+    lea     r8, [r8+8]
+
+%endmacro
+
+%macro addmulpropro3 0
+
+%endmacro
+
+%macro addmulpro3 0
+
+    imul    r13, rcx
+    mov     rax, [rsi+r14*8]
+    mov     r11, r14
+    mul     r13
+    mov     r12, rax
+    mov     rax, [rsi+r14*8+8]
+    mov     r9, rdx
+    cmp     r14, 0
+
+%endmacro
+
+%macro addmulnext3 0
+
+    mul     r13
+    add     [r8+r11*8], r12
+    adc     r9, rax
+    mov     r10d, 0
+    adc     r10, rdx
+    add     [r8+r11*8+8], r9
+    adc     r10, 0
+    mov     r13, [r8+r14*8+8]
+    mov     [r8+r14*8], r10
+    lea     r8, [r8+8]
+    sub     r15, 1          ; ***
+
+%endmacro
+
+%macro mpn_addmul_1_int 1
+
+    addmulpropro%1
+    xalign  16
+%%1:addmulpro%1
+    jge     %%2
+    addmulloop %1
+%%2:addmulnext%1
+    jnz     %%1
+
+%endmacro
+
+    LEAF_PROC mpn_redc_1
+    cmp     r9, 1
+    je      one
+    FRAME_PROC ?mpn_sandybridge_redc_1, 0, reg_save_list
+    mov     rdi, rcx
+    mov     rsi, r8
+    mov     r8, rdx
+    mov     rdx, r9
+    mov     rcx, [rsp+stack_use+0x28]
+    mov     [rsp+stack_use+0x28], r8
+
+    mov     r14, 5
+    sub     r14, rdx
+
+    mov     [rsp+stack_use+0x10], rsi
+    mov     r8, [rsp+stack_use+0x28]
+
+    lea     r8, [r8+rdx*8-40]
+    lea     rsi, [rsi+rdx*8-40]
+    mov     rbp, rdx
+    mov     r15, rdx
+    mov     rax, r14
+    and     rax, 3
+    mov     r13, [r8+r14*8]
+    je      .2
+    jp      .4
+    cmp     rax, 1
+    je      .3
+.1:	mpn_addmul_1_int 2
+    jmp     .5
+
+    xalign  16
+.2:	mpn_addmul_1_int 0
+    jmp     .5
+
+    xalign  16
+.3:	mpn_addmul_1_int 1
+    jmp     .5
+
+    xalign  16
+.4:	mpn_addmul_1_int 3
+
+    xalign  16
+.5:	mov     rcx, rbp
+    mov     rdx, [rsp+stack_use+0x28]
+    lea     rsi, [rdx+rbp*8]
+    mov     rbx, rdi
+    mpn_add
+    mov     rdx, [rsp+stack_use+0x10]
+    jnc     .6
+    mov     rsi, rbx
+    mpn_sub
+.6:	END_PROC reg_save_list
+
+    xalign  16
+one:mov     r9, rdx
+    mov     r11, [r8]
+    mov     r8, [rsp+0x28]
+
+    mov     r10, [r9]
+    imul    r8, r10
+    mov     rax, r8
+    mul     r11
+    add     rax, r10
+    adc     rdx, [r9+8]
+    cmovnc  r11, rax
+    sub     rdx, r11
+    mov     [rcx], rdx
+    ret
+
+    end

--- a/SMP/yasm/sandybridge/rsh_divrem_hensel_qr_1_1.asm
+++ b/SMP/yasm/sandybridge/rsh_divrem_hensel_qr_1_1.asm
@@ -1,0 +1,123 @@
+; PROLOGUE(mpn_rsh_divrem_hensel_qr_1_1)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_rsh_divrem_hensel_qr_1_1(mp_ptr, mp_ptr, mp_size_t, mp_limb_t,  mp_int, mp_limb_t)
+;  rax                                        rdi     rsi        rdx        rcx       r8         r9
+;  rax                                        rcx     rdx         r8         r9 [rsp+40]   [rsp+48]
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi
+
+	FRAME_PROC mpn_rsh_divrem_hensel_qr_1_1, 0, reg_save_list
+    mov     rax, r8
+	lea     rdi, [rcx+rax*8]
+	lea     rsi, [rdx+rax*8]
+    mov     rcx, r9
+	mov     rdx, r9
+	mov     r9, 1
+	sub     r9, rax
+    movsxd  r8, dword [rsp+stack_use+40]
+    mov     r10, qword [rsp+stack_use+48]
+    
+	mov     rax, rdx
+	imul    edx, ecx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11d, eax
+
+	mov     rax, r11
+	imul    r11d, ecx
+	mov     rdx, 2
+	sub     rdx, r11
+	imul    edx, eax
+
+	mov     rax, rdx
+	imul    edx, ecx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11d, eax
+
+	mov     rax, r11
+	imul    r11d, ecx
+	mov     rdx, 2
+	sub     rdx, r11
+	imul    edx, eax
+
+	mov     rax, rdx
+	imul    rdx, rcx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11, rax
+
+	mov     rax, 64
+	sub     rax, r8
+	movq    mm0, r8
+	movq    mm1, rax
+	mov     rax, [rsi+r9*8-8]
+	sub     rax, r10
+	sbb     r8, r8
+	imul    rax, r11
+	movq    mm4, rax
+	movq    mm5, mm4
+	psrlq   mm4, mm0
+	psllq   mm5, mm1
+	psrlq   mm5, mm1
+	mul     rcx
+	cmp     r9, 0
+	je      .3
+	add     r8, r8
+	
+	xalign  16
+.1:	movq    mm2, mm4
+	mov     rax, [rsi+r9*8]
+	sbb     rax, rdx
+	sbb     r8, r8
+	imul    rax, r11
+	movq    mm3, rax
+	movq    mm4, mm3
+	psllq   mm3, mm1
+	psrlq   mm4, mm0
+	por     mm2, mm3
+	movq    [rdi+r9*8-8], mm2
+	mul     rcx
+	add     r8, r8
+	inc     r9
+	jnz     .1
+.2:	movq    [rdi+r9*8-8], mm4
+	mov     rax, 0
+	adc     rax, rdx
+	emms
+	EXIT_PROC reg_save_list
+
+.3:	movq    [rdi+r9*8-8], mm4
+	add     r8, r8
+	mov     rax, 0
+	adc     rax, rdx
+.4:	emms
+	END_PROC reg_save_list
+
+    end

--- a/SMP/yasm/sandybridge/rsh_divrem_hensel_qr_1_2.asm
+++ b/SMP/yasm/sandybridge/rsh_divrem_hensel_qr_1_2.asm
@@ -1,0 +1,225 @@
+; PROLOGUE(mpn_rsh_divrem_hensel_qr_1_2)
+
+;  Copyright 2009 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_rsh_divrem_hensel_qr_1_2(mp_ptr, mp_ptr, mp_size_t, mp_limb_t, mp_uint, mp_limb_t)
+;  rax                                        rdi     rsi        rdx        rcx       r8         r9
+;  rax                                        rcx     rdx         r8         r9 [rsp+40]   [rsp+48]
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi, r12, r13, r14
+
+	FRAME_PROC mpn_rsh_divrem_hensel_qr_1_2, 0, reg_save_list
+    mov     rax, r8
+	lea     rdi, [rcx+rax*8-16]
+	lea     rsi, [rdx+rax*8-16]
+    mov     rcx, r9
+    mov     rdx, r9
+	mov     r9, 2
+	sub     r9, rax    
+    mov     r8d, dword [rsp+stack_use+40]
+    mov     r10, qword [rsp+stack_use+48]
+
+	mov     rax, 64
+	sub     rax, r8
+	movq    mm0, r8
+	movq    mm1, rax
+
+	mov     rax, rdx
+	imul    edx, ecx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11d, eax
+
+	mov     rax, r11
+	imul    r11d, ecx
+	mov     rdx, 2
+	sub     rdx, r11
+	imul    edx, eax
+
+	mov     rax, rdx
+	imul    edx, ecx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11d, eax
+
+	mov     rax, r11
+	imul    r11d, ecx
+	mov     rdx, 2
+	sub     rdx, r11
+	imul    edx, eax
+
+	mov     rax, rdx
+	imul    rdx, rcx
+	mov     r11, 2
+	sub     r11, rdx
+	imul    r11, rax
+
+	mov     rax, r11
+	mov     r12, r11
+	mul     rcx
+	neg     rdx
+	imul    r12, rdx
+
+; // for the first limb we can not store (as we have to shift) so we need to
+; // do first limb separately , we could do it as normal as an extention of
+; // the loop , but if we do it as a 1 limb inverse then we can start it
+; // eailer , ie interleave it with the calculation of the 2limb inverse
+
+	mov     r13, r11
+	mov     r14, r12
+
+	mov     r11, [rsi+r9*8]
+	sub     r11, r10
+	sbb     r10, r10
+
+	imul    r11, r13
+	movq    mm2, r11
+	psrlq   mm2, mm0
+	mov     rax, rcx
+	mul     r11
+	mov     r11, [rsi+r9*8+8]
+	mov     r12, [rsi+r9*8+16]
+	add     r10, r10
+	sbb     r11, rdx
+	sbb     r12, 0
+	sbb     r10, r10
+
+; mov $0,%r10
+	add     r9, 2
+	jc      .2
+	xalign  16
+.1:	mov     r8, r12
+	mov     rax, r13
+	mul     r11
+
+	; mov %rax,-16(%rdi,%r9,8)	#// store low quotient
+	movq    mm3, rax
+	movq    mm4, mm3
+	psllq   mm3, mm1
+	psrlq   mm4, mm0
+	por     mm2, mm3
+	movq    [rdi+r9*8-16], mm2
+
+	imul    r11, r14
+	imul    r12, r13
+	add     rdx, r11
+	add     rdx, r12
+	mov     r11, [rsi+r9*8+8]
+	mov     r12, [rsi+r9*8+16]
+
+	; mov %rdx,-8(%rdi,%r9,8)	#// store high quotient
+	movq    mm3, rdx
+	movq    mm2, mm3
+	psllq   mm3, mm1
+	psrlq   mm2, mm0
+	por     mm4, mm3
+	movq    [rdi+r9*8-8], mm4
+
+	mov     rax, rcx
+	mul     rdx
+	add     r10, r10
+	sbb     r11, 0
+	sbb     r12, 0
+	sbb     r10, r10
+	cmp     r8, rax
+	sbb     r11, rdx
+	sbb     r12, 0
+	sbb     r10, 0
+	add     r9, 2
+	jnc     .1
+.2:	mov     r8, r12
+	mov     rax, r13
+	mul     r11
+
+; mov %rax,-16(%rdi,%r9,8)	#// store low quotient
+	movq    mm3, rax
+	movq    mm4, mm3
+	psllq   mm3, mm1
+	psrlq   mm4, mm0
+	por     mm2, mm3
+	movq    [rdi+r9*8-16], mm2
+
+	imul    r11, r14
+	imul    r12, r13
+	add     rdx, r11
+	add     rdx, r12
+	cmp     r9, 0
+	jne     .4
+.3:	mov     r11, [rsi+r9*8+8]
+	; mov %rdx,-8(%rdi,%r9,8)	#// store high quotient
+	movq    mm3, rdx
+	movq    mm2, mm3
+	psllq   mm3, mm1
+	psrlq   mm2, mm0
+	por     mm4, mm3
+	movq    [rdi+r9*8-8], mm4
+
+	mov     rax, rcx
+	mul     rdx
+	add     r10, r10
+	sbb     r11, 0
+	sbb     r10, r10
+	cmp     r8, rax
+	sbb     r11, rdx
+	sbb     r10, 0
+	mov     rax, r11
+	imul    rax, r13
+	; mov %rax,(%rdi,%r9,8)
+	movq    mm3, rax
+	movq    mm4, mm3
+	psllq   mm3, mm1
+	psrlq   mm4, mm0
+	por     mm2, mm3
+	movq    [rdi+r9*8], mm2
+	movq    [rdi+r9*8+8], mm4
+
+	mul     rcx
+	add     r10, r10
+	mov     rax, 0
+	adc     rax, rdx
+	emms
+	EXIT_PROC reg_save_list
+
+	; mov %rdx,-8(%rdi,%r9,8)	#// store high quotient
+.4:	movq    mm3, rdx
+	movq    mm2, mm3
+	psllq   mm3, mm1
+	psrlq   mm2, mm0
+	por     mm4, mm3
+	movq    [rdi+r9*8-8], mm4
+	movq    [rdi+r9*8], mm2
+
+	mov     rax, rcx
+	mul     rdx
+	cmp     r8, rax
+	mov     rax, 0
+	adc     rax, rdx
+	sub     rax, r10
+.5:	emms
+	END_PROC reg_save_list
+
+    end

--- a/SMP/yasm/sandybridge/rshift.asm
+++ b/SMP/yasm/sandybridge/rshift.asm
@@ -1,0 +1,171 @@
+; PROLOGUE(mpn_rshift)
+
+;  Version 1.0.4.
+;
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t  mpn_rshift(mp_ptr, mp_ptr, mp_size_t, mp_uint)
+;  rax                     rdi      rsi        rdx      rcx
+;  rax                     rcx      rdx         r8      r9d
+
+%include "yasm_mac.inc"
+
+    CPU  SSE4.2
+    BITS 64
+
+    LEAF_PROC mpn_rshift
+    mov     r10, rcx
+    mov     ecx, r9d
+    cmp     r8, 2
+    ja      .3
+    jz      .2
+.1:	mov     rdx, [rdx]
+    mov     rax, rdx
+    shr     rdx, cl
+    neg     rcx
+    shl     rax, cl
+    mov     [r10], rdx
+    ret
+
+.2:	mov     r8, [rdx]
+    mov     r9, [rdx+8]
+    mov     rax, r8
+    mov     r11, r9
+    shr     r8, cl
+    shr     r9, cl
+    neg     rcx
+    shl     r11, cl
+    shl     rax, cl
+    or      r8, r11
+    mov     [r10], r8
+    mov     [r10+8], r9
+    ret
+
+.3:	mov     r11, rdx
+    mov     rdx, r8
+
+    mov     eax, 64
+    lea     r9, [r11+8]
+    sub     rax, rcx
+    and     r9, -16
+    movq    xmm0, rcx
+    movq    xmm1, rax
+    movdqa  xmm5, [r9]
+    movdqa  xmm3, xmm5
+    psllq   xmm5, xmm1
+    movq    rax, xmm5
+    cmp     r11, r9
+    lea     r11, [r11+rdx*8-40]
+    je      .4
+    movq    xmm2, [r9-8]
+    movq    xmm4, xmm2
+    psllq   xmm2, xmm1
+    psrlq   xmm4, xmm0
+    por     xmm4, xmm5
+    movq    [r10], xmm4
+    lea     r10, [r10+8]
+    dec     rdx
+    movq    rax, xmm2
+.4: lea     r10, [r10+rdx*8-40]
+    psrlq   xmm3, xmm0
+    mov     r8d, 5
+    sub     r8, rdx
+    jnc     .6
+
+    xalign  16
+.5: movdqa  xmm2, [r11+r8*8+16]
+    movdqa  xmm4, xmm2
+    psllq   xmm2, xmm1
+    shufpd  xmm5, xmm2, 1
+    por     xmm3, xmm5
+    movq    [r10+r8*8], xmm3
+    movhpd  [r10+r8*8+8], xmm3
+    psrlq   xmm4, xmm0
+    movdqa  xmm5, [r11+r8*8+32]
+    movdqa  xmm3, xmm5
+    psllq   xmm5, xmm1
+    shufpd  xmm2, xmm5, 1
+    psrlq   xmm3, xmm0
+    por     xmm4, xmm2
+    movq    [r10+r8*8+16], xmm4
+    movhpd  [r10+r8*8+24], xmm4
+    add     r8, 4
+    jnc     .5
+.6: cmp     r8, 2
+    ja      .10
+    jz      .9
+    jp      .8
+.7:	movdqa  xmm2, [r11+r8*8+16]
+    movdqa  xmm4, xmm2
+    psllq   xmm2, xmm1
+    shufpd  xmm5, xmm2, 1
+    por     xmm3, xmm5
+    movq    [r10+r8*8], xmm3
+    movhpd  [r10+r8*8+8], xmm3
+    psrlq   xmm4, xmm0
+    movq    xmm5, [r11+r8*8+32]
+    movq    xmm3, xmm5
+    psllq   xmm5, xmm1
+    shufpd  xmm2, xmm5, 1
+    psrlq   xmm3, xmm0
+    por     xmm4, xmm2
+    movq    [r10+r8*8+16], xmm4
+    movhpd  [r10+r8*8+24], xmm4
+    psrldq  xmm5, 8
+    por     xmm3, xmm5
+    movq    [r10+r8*8+32], xmm3
+    ret
+
+    xalign  16
+.8:	movdqa  xmm2, [r11+r8*8+16]
+    movdqa  xmm4, xmm2
+    psllq   xmm2, xmm1
+    shufpd  xmm5, xmm2, 1
+    por     xmm3, xmm5
+    movq    [r10+r8*8], xmm3
+    movhpd  [r10+r8*8+8], xmm3
+    psrlq   xmm4, xmm0
+    psrldq  xmm2, 8
+    por     xmm4, xmm2
+    movq    [r10+r8*8+16], xmm4
+    movhpd  [r10+r8*8+24], xmm4
+    ret
+
+    xalign  16
+.9:	movq    xmm2, [r11+r8*8+16]
+    movq    xmm4, xmm2
+    psllq   xmm2, xmm1
+    shufpd  xmm5, xmm2, 1
+    por     xmm3, xmm5
+    movq    [r10+r8*8], xmm3
+    movhpd  [r10+r8*8+8], xmm3
+    psrlq   xmm4, xmm0
+    psrldq  xmm2, 8
+    por     xmm4, xmm2
+    movq    [r10+r8*8+16], xmm4
+    ret
+
+    xalign  16
+.10:psrldq  xmm5, 8
+    por     xmm3, xmm5
+    movq    [r10+r8*8], xmm3
+    movhpd  [r10+r8*8+8], xmm3
+    ret
+
+    end

--- a/SMP/yasm/sandybridge/store.asm
+++ b/SMP/yasm/sandybridge/store.asm
@@ -1,0 +1,68 @@
+; PROLOGUE(mpn_store)
+
+;  mpn_store
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_store(mp_ptr, mp_size_t, mp_limb_t)
+;                    rdi,       rsi,       rdx
+;                    rcx,       rdx,        r8
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+%define	MOVQ	movd
+
+	LEAF_PROC mpn_store
+	lea     rcx, [rcx-32]
+	cmp     rdx, 0
+	jz      .4
+	MOVQ    xmm0, r8
+	movddup xmm0, xmm0
+	test    rcx, 0xF
+	jz      .1
+	mov     [rcx+32], r8
+	lea     rcx, [rcx+8]
+	sub     rdx, 1
+.1:	sub     rdx, 4
+	jc      .3
+	
+	xalign  16
+.2:	lea     rcx, [rcx+32]
+	sub     rdx, 4
+	movdqa  [rcx], xmm0
+	movdqa  [rcx+16], xmm0
+	jnc     .2
+.3:	cmp     rdx, -2
+	ja      .5
+	jz      .7
+	jp      .6
+.4:	ret
+
+.5:	movdqa  [rcx+32], xmm0
+.6:	mov     [rcx+rdx*8+56], r8
+	ret
+
+.7:	movdqa  [rcx+32], xmm0
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/sub_n.asm
+++ b/SMP/yasm/sandybridge/sub_n.asm
@@ -1,0 +1,112 @@
+; PROLOGUE(mpn_sub_n)
+
+;  Version 1.0.3.
+;
+;  Copyright 2008 Jason Moxham
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  Calculate src1[size] plus(minus) src2[size] and store the result in
+;  dst[size].  The return value is the carry bit from the top of the result
+;  (1 or 0).  The _nc version accepts 1 or 0 for an initial carry into the
+;  low limb of the calculation.  Note values other than 1 or 0 here will
+;  lead to garbage results.
+;
+;  mp_limb_t  mpn_sub_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;  mp_limb_t mpn_sub_nc(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t, mp_limb_t)
+;  rax                     rdi        rsi        rdx        rcx         r8
+;  rax                     rcx        rdx         r8         r9   [rsp+40]
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+    xalign  8
+    LEAF_PROC mpn_sub_nc
+    mov     r10,[rsp+40]
+    jmp     entry
+
+    xalign  8
+    LEAF_PROC mpn_sub_n
+    xor     r10, r10
+entry:
+    mov     rax, r9
+    and     rax, 3
+    shr     r9, 2
+    lea     r9,[r10+r9*2]
+	sar     r9, 1
+    jnz     .2
+
+    mov     r10, [rdx]
+    sbb     r10, [r8]
+    mov     [rcx], r10
+    dec     rax
+    jz      .1
+    mov     r10, [rdx+8]
+    sbb     r10, [r8+8]
+    mov     [rcx+8], r10
+    dec     rax
+    jz      .1
+    mov     r10, [rdx+16]
+    sbb     r10, [r8+16]
+    mov     [rcx+16], r10
+    dec     rax
+.1: adc     rax, rax
+    ret
+
+    xalign  8
+.2:	mov     r10, [rdx]
+    mov     r11, [rdx+8]
+    lea     rdx, [rdx+32]
+    sbb     r10, [r8]
+    sbb     r11, [r8+8]
+    lea     r8, [r8+32]
+    mov     [rcx], r10
+    mov     [rcx+8], r11
+    lea     rcx, [rcx+32]
+    mov     r10, [rdx-16]
+    mov     r11, [rdx-8]
+    sbb     r10, [r8-16]
+    sbb     r11, [r8-8]
+    mov     [rcx-16], r10
+    dec     r9
+    mov     [rcx-8], r11
+    jnz     .2
+
+    inc     rax
+    dec     rax
+    jz      .3
+    mov     r10, [rdx]
+    sbb     r10, [r8]
+    mov     [rcx], r10
+    dec     rax
+    jz      .3
+    mov     r10, [rdx+8]
+    sbb      r10, [r8+8]
+    mov     [rcx+8], r10
+    dec     rax
+    jz      .3
+    mov     r10, [rdx+16]
+    sbb     r10, [r8+16]
+    mov     [rcx+16], r10
+    dec     rax
+.3: adc     rax, rax
+    ret
+
+    end

--- a/SMP/yasm/sandybridge/submul_1.asm
+++ b/SMP/yasm/sandybridge/submul_1.asm
@@ -1,0 +1,156 @@
+; PROLOGUE(mpn_submul_1)
+        
+;  Copyright 2011 The Code Cavern  
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either version 2.1 of the License, or (at
+;  your option) any later version.
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_submul_1(mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  mp_limb_t mpn_declsh_n(mp_ptr, mp_ptr, mp_size_t,   mp_uint)
+;  rax                       rdi     rsi        rdx        rcx
+;  rax                       rcx     rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+    CPU  Athlon64
+    BITS 64
+
+%define reg_save_list rsi, rdi, r12
+
+  
+        xalign 16
+        LEAF_PROC mpn_submul_1
+        mov     rax, [rdx]
+        cmp     r8, 1
+        jnz     .1
+        mul     r9
+        sub     [rcx], rax
+        adc     rdx, 0
+        mov     rax, rdx
+        ret
+
+        xalign   16
+.1:	    FRAME_PROC ?mpn_sandybridge_submul, 0, reg_save_list
+        mov     r11, 5
+        lea     rsi, [rdx+r8*8-40]
+        lea     rdi, [rcx+r8*8-40]
+        mov     rcx, r9
+        sub     r11, r8
+        mul     rcx
+        db      0x26
+        mov     r8, rax
+        db      0x26
+        mov     rax, [rsi+r11*8+8]
+        db      0x26
+        mov     r9, rdx
+        db      0x26
+        cmp     r11, 0
+        db      0x26
+        mov     [rsp-8], r12
+        db      0x26
+        jge     .3
+.2:     xor     r10, r10
+        mul     rcx
+        sub     [rdi+r11*8], r8
+        adc     r9, rax
+        adc     r10, rdx
+        mov     rax, [rsi+r11*8+16]
+        mul     rcx
+        sub     [rdi+r11*8+8], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+r11*8+24]
+        xor     r8, r8
+        xor     r9, r9
+        mul     rcx
+        sub     [rdi+r11*8+16], r10
+        adc     r12, rax
+        adc     r8, rdx
+        mov     rax, [rsi+r11*8+32]
+        mul     rcx
+        sub     [rdi+r11*8+24], r12
+        adc     r8, rax
+        adc     r9, rdx
+        add     r11, 4
+        mov     rax, [rsi+r11*8+8]
+        jnc     .2
+.3:     xor     r10, r10
+        mul     rcx
+        sub     [rdi+r11*8], r8
+        adc     r9, rax
+        adc     r10, rdx
+        cmp     r11, 2
+        ja      .7
+        jz      .6
+        jp      .5
+.4:     mov     rax, [rsi+16]
+        mul     rcx
+        sub     [rdi+8], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+24]
+        xor     r8, r8
+        xor     r9, r9
+        mul     rcx
+        sub     [rdi+16], r10
+        adc     r12, rax
+        adc     r8, rdx
+        mov     rax, [rsi+32]
+        mul     rcx
+        sub     [rdi+24], r12
+        adc     r8, rax
+        adc     r9, rdx
+        sub     [rdi+32], r8
+        adc     r9, 0
+        mov     rax, r9
+        EXIT_PROC reg_save_list
+.5:     mov     rax, [rsi+24]
+        mul     rcx
+        sub     [rdi+16], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        mov     rax, [rsi+32]
+        xor     r8, r8
+        mul     rcx
+        sub     [rdi+24], r10
+        adc     r12, rax
+        adc     r8, rdx
+        sub     [rdi+32], r12
+        adc     r8, 0
+        mov     rax, r8
+        EXIT_PROC reg_save_list
+
+        align   16
+.6:     mov     rax, [rsi+32]
+        mul     rcx
+        sub     [rdi+24], r9
+        adc     r10, rax
+        mov     r12d, 0
+        adc     r12, rdx
+        sub     [rdi+32], r10
+        adc     r12, 0
+        mov     rax, r12
+        EXIT_PROC reg_save_list
+.7:     sub     [rdi+32], r9
+        adc     r10, 0
+        mov     rax, r10
+        END_PROC reg_save_list
+
+        end

--- a/SMP/yasm/sandybridge/xnor_n.asm
+++ b/SMP/yasm/sandybridge/xnor_n.asm
@@ -1,0 +1,84 @@
+; PROLOGUE(mpn_xnor_n)
+
+;  mpn_xnor_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_xnor_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                     rcx        rdx         r8         r9
+;                     rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_xnor_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	pcmpeqb xmm4, xmm4
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm1, [r8+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	add     r10, 4
+	movdqu  xmm3, [rdx+r10*8+16-32]
+	pxor    xmm1, xmm3
+	pxor    xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8-32], xmm0
+	pxor    xmm1, xmm4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [r8+r10*8]
+	mov     rax, [r8+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	mov     r9, [rdx+r10*8+16]
+	xor     rax, r9
+	pxor    xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	not     rax
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+.5:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm2, [rdx+r10*8]
+	pxor    xmm0, xmm2
+	pxor    xmm0, xmm4
+	movdqu  [rcx+r10*8], xmm0
+	ret
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	xor     rax, r9
+	not     rax
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sandybridge/xor_n.asm
+++ b/SMP/yasm/sandybridge/xor_n.asm
@@ -1,0 +1,79 @@
+; PROLOGUE(mpn_xor_n)
+
+;  mpn_xor_n
+
+;  Copyright 2009 Jason Moxham
+
+;  This file is part of the MPIR Library.
+
+;  The MPIR Library is free software; you can redistribute it and/or modify
+;  it under the terms of the GNU Lesser General Public License as published
+;  by the Free Software Foundation; either verdxon 2.1 of the License, or (at
+;  your option) any later verdxon.
+
+;  The MPIR Library is distributed in the hope that it will be useful, but
+;  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+;  License for more details.
+
+;  You should have received a copy of the GNU Lesser General Public License
+;  along with the MPIR Library; see the file COPYING.LIB.  If not, write
+;  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;  Boston, MA 02110-1301, USA.
+
+;  void mpn_xor_n(mp_ptr, mp_srcptr, mp_srcptr, mp_size_t)
+;                    rcx        rdx         r8         r9
+;                    rdi        rsi        rdx        rcx 
+
+%include 'yasm_mac.inc'
+
+    CPU  nehalem
+    BITS 64
+
+	LEAF_PROC mpn_xor_n
+	movsxd	r9, r9d
+	mov     r10, 3
+	lea     rdx, [rdx+r9*8-24]
+	lea     r8, [r8+r9*8-24]
+	lea     rcx, [rcx+r9*8-24]
+	sub     r10, r9
+	jnc     .2
+	
+	xalign  16
+.1:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm1, [r8+r10*8+16]
+	movdqu  xmm3, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	pxor    xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	pxor    xmm1, xmm3
+	add     r10, 4
+	movdqu  [rcx+r10*8+16-32], xmm1
+	jnc     .1
+.2:	cmp     r10, 2
+	ja      .4
+	je      .6
+	jp      .5
+.3:	movdqu  xmm0, [r8+r10*8]
+	mov     rax, [r8+r10*8+16]
+	mov     r9, [rdx+r10*8+16]
+	movdqu  xmm2, [rdx+r10*8]
+	pxor    xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	xor     rax, r9
+	mov     [rcx+r10*8+16], rax
+.4:	ret
+
+.5:	movdqu  xmm0, [r8+r10*8]
+	movdqu  xmm2, [rdx+r10*8]
+	pxor    xmm0, xmm2
+	movdqu  [rcx+r10*8], xmm0
+	ret
+
+.6:	mov     rax, [r8+r10*8]
+	mov     r9, [rdx+r10*8]
+	xor     rax, r9
+	mov     [rcx+r10*8], rax
+	ret
+	
+	end

--- a/SMP/yasm/sqr_basecase.asm
+++ b/SMP/yasm/sqr_basecase.asm
@@ -1,0 +1,645 @@
+
+; void mpn_sqr_basecase (mp_ptr, mp_srcptr, mp_size_t)
+;  rax                      rdi        rsi        rdx
+;  rax                      rcx        rdx         r8
+
+%include 'yasm_mac.inc'
+
+%define reg_save_list   rbx, rbp, rsi, rdi, r12, r13, r14
+
+%macro jmp_tab 2
+	%ifdef PIC
+		dd	%1 - %2
+	%else
+		dq	%1
+	%endif
+%endmacro
+
+%macro	do_jmp 0
+	lea     rax, [rel L0]
+	%ifdef PIC
+		mov     r10d, [rax+rcx*4]
+		add     rax, r10
+		jmp     rax
+	%else
+		jmp     [rax+rcx*8]
+	%endif
+%endmacro
+
+	text
+	xalign  16
+	WIN64_GCC_PROC mpn_sqr_basecase, 3
+	mov     ecx, edx
+	mov     r11d, edx
+	and     ecx, 3
+	cmp     edx, 4
+	lea     r8, [rcx+4]
+	cmovg   rcx, r8
+	do_jmp
+
+	xalign  8
+L0:	jmp_tab L4, L0
+	jmp_tab L1, L0
+	jmp_tab L2, L0
+	jmp_tab L3, L0
+	jmp_tab	L5, L0
+	jmp_tab L8, L0
+	jmp_tab L12, L0
+	jmp_tab L15, L0
+
+L1:	mov     rax, [rsi]
+	mul     rax
+	mov     [rdi], rax
+	mov     [rdi+8], rdx
+	WIN64_GCC_EXIT
+
+L2:	mov     rax, [rsi]
+	mov     r8, rax
+	mul     rax
+	mov     r11, [rsi+8]
+	mov     [rdi], rax
+	mov     rax, r11
+	mov     r9, rdx
+	mul     rax
+	mov     r10, rax
+	mov     rax, r11
+	mov     r11, rdx
+	mul     r8
+	xor     r8, r8
+	add     r9, rax
+	adc     r10, rdx
+	adc     r11, r8
+	add     r9, rax
+	mov     [rdi+8], r9
+	adc     r10, rdx
+	mov     [rdi+16], r10
+	adc     r11, r8
+	mov     [rdi+24], r11
+	WIN64_GCC_EXIT
+
+L3:	mov     rax, [rsi]
+	mov     r10, rax
+	mul     rax
+	mov     r11, [rsi+8]
+	mov     [rdi], rax
+	mov     rax, r11
+	mov     [rdi+8], rdx
+	mul     rax
+	mov     rcx, [rsi+16]
+	mov     [rdi+16], rax
+	mov     rax, rcx
+	mov     [rdi+24], rdx
+	mul     rax
+	mov     [rdi+32], rax
+	mov     [rdi+40], rdx
+	mov     rax, r11
+	mul     r10
+	mov     r8, rax
+	mov     rax, rcx
+	mov     r9, rdx
+	mul     r10
+	xor     r10, r10
+	add     r9, rax
+	mov     rax, r11
+	mov     r11, r10
+	adc     r10, rdx
+	mul     rcx
+	add     r10, rax
+	adc     rdx, r11
+	add     r8, r8
+	adc     r9, r9
+	adc     r10, r10
+	adc     rdx, rdx
+	adc     r11, r11
+	add     [rdi+8], r8
+	adc     [rdi+16], r9
+	adc     [rdi+24], r10
+	adc     [rdi+32], rdx
+	adc     [rdi+40], r11
+	WIN64_GCC_EXIT
+
+L4:	mov     rax, [rsi]
+	mov     r11, rax
+	mul     rax
+	mov     rbx, [rsi+8]
+	mov     [rdi], rax
+	mov     rax, rbx
+	mov     [rdi+8], rdx
+	mul     rax
+	mov     [rdi+16], rax
+	mov     [rdi+24], rdx
+	mov     rax, [rsi+16]
+	mul     rax
+	mov     [rdi+32], rax
+	mov     [rdi+40], rdx
+	mov     rax, [rsi+24]
+	mul     rax
+	mov     [rdi+48], rax
+	mov     rax, rbx
+	mov     [rdi+56], rdx
+	mul     r11
+	mov     r8, rax
+	mov     r9, rdx
+	mov     rax, [rsi+16]
+	mul     r11
+	xor     r10, r10
+	add     r9, rax
+	adc     r10, rdx
+	mov     rax, [rsi+24]
+	mul     r11
+	xor     r11, r11
+	add     r10, rax
+	adc     r11, rdx
+	mov     rax, [rsi+16]
+	mul     rbx
+	xor     rcx, rcx
+	add     r10, rax
+	adc     r11, rdx
+	adc     rcx, 0
+	mov     rax, [rsi+24]
+	mul     rbx
+	add     r11, rax
+	adc     rcx, rdx
+	mov     rdx, [rsi+16]
+	mov     rax, [rsi+24]
+	mul     rdx
+	add     rcx, rax
+	adc     rdx, 0
+	add     r8, r8
+	adc     r9, r9
+	adc     r10, r10
+	adc     r11, r11
+	adc     rcx, rcx
+	mov     eax, 0
+	adc     rdx, rdx
+	adc     rax, rax
+	add     [rdi+8], r8
+	adc     [rdi+16], r9
+	adc     [rdi+24], r10
+	adc     [rdi+32], r11
+	adc     [rdi+40], rcx
+	adc     [rdi+48], rdx
+	adc     [rdi+56], rax
+	WIN64_GCC_EXIT
+
+L5:	lea     r12, [rdi+r11*8-16]
+	mov     r13, [rsi]
+	mov     rax, [rsi+8]
+	lea     rsi, [rsi+r11*8]
+	lea     r8, [r11-4]
+	xor     r9d, r9d
+	sub     r9, r11
+	mul     r13
+	xor     ebp, ebp
+	mov     rbx, rax
+	mov     rax, [rsi+r9*8+16]
+	mov     r10, rdx
+	jmp     .7
+
+	xalign  16
+.6:	add     rbp, rax
+	mov     [r12+r9*8], r10
+	mov     rax, [rsi+r9*8]
+	adc     rcx, rdx
+	xor     ebx, ebx
+	mul     r13
+	xor     r10d, r10d
+	mov     [r12+r9*8+8], rbp
+	add     rcx, rax
+	adc     rbx, rdx
+	mov     rax, [rsi+r9*8+8]
+	mov     [r12+r9*8+16], rcx
+	xor     ebp, ebp
+	mul     r13
+	add     rbx, rax
+	mov     rax, [rsi+r9*8+16]
+	adc     r10, rdx
+.7:	xor     ecx, ecx
+	mul     r13
+	add     r10, rax
+	mov     rax, [rsi+r9*8+24]
+	adc     rbp, rdx
+	mov     [r12+r9*8+24], rbx
+	mul     r13
+	add     r9, 4
+	js      .6
+	add     rbp, rax
+	mov     [r12], r10
+	adc     rcx, rdx
+	mov     [r12+8], rbp
+	mov     [r12+16], rcx
+	lea		r12, [r12+16]
+	lea     rsi, [rsi-8]
+	jmp     L18
+
+L8:	lea     r12, [rdi+r11*8+8]
+	mov     r13, [rsi]
+	mov     rax, [rsi+8]
+	lea     rsi, [rsi+r11*8+8]
+	lea     r8, [r11-3]
+	lea     r9, [r11-3]
+	neg     r9
+	mov     r14, rax
+	mul     r13
+	mov     rcx, rdx
+	xor     ebp, ebp
+	mov     [rdi+8], rax
+	jmp     .10
+
+	xalign  16
+.9:	mul     r14
+	add     rbx, rax
+	adc     rcx, rdx
+	mov     rax, [rsi+r9*8-24]
+	mov     ebp, 0
+	mul     r13
+	add     rbx, rax
+	mov     rax, [rsi+r9*8-24]
+	adc     rcx, rdx
+	adc     ebp, 0
+	mul     r14
+	add     rcx, rax
+	mov     [r12+r9*8-24], rbx
+	adc     rbp, rdx
+.10:mov     rax, [rsi+r9*8-16]
+	mul     r13
+	mov     r10d, 0
+	add     rcx, rax
+	adc     rbp, rdx
+	mov     rax, [rsi+r9*8-16]
+	adc     r10d, 0
+	mov     ebx, 0
+	mov     [r12+r9*8-16], rcx
+	mul     r14
+	add     rbp, rax
+	mov     rax, [rsi+r9*8-8]
+	adc     r10, rdx
+	mov     ecx, 0
+	mul     r13
+	add     rbp, rax
+	mov     rax, [rsi+r9*8-8]
+	adc     r10, rdx
+	adc     ebx, 0
+	mul     r14
+	add     r10, rax
+	mov     [r12+r9*8-8], rbp
+	adc     rbx, rdx
+.11:mov     rax, [rsi+r9*8]
+	mul     r13
+	add     r10, rax
+	adc     rbx, rdx
+	adc     ecx, 0
+	add     r9, 4
+	mov     rax, [rsi+r9*8-32]
+	mov     [r12+r9*8-32], r10
+	js      .9
+	mul     r14
+	add     rbx, rax
+	adc     rcx, rdx
+	mov     [r12-8], rbx
+	mov     [r12], rcx
+	lea     rsi, [rsi-16]
+	jmp     L24
+
+L12:lea     r12, [rdi+r11*8-16]
+	mov     r13, [rsi]
+	mov     rax, [rsi+8]
+	lea     rsi, [rsi+r11*8]
+	lea     r8, [r11-4]
+	lea     r9, [r11-2]
+	neg     r9
+	mul     r13
+	mov     rbp, rax
+	mov     rax, [rsi+r9*8]
+	mov     rcx, rdx
+	jmp     .14
+	
+	xalign  16
+.13:add     rbp, rax
+	mov     [r12+r9*8], r10
+	mov     rax, [rsi+r9*8]
+	adc     rcx, rdx
+.14:xor     ebx, ebx
+	mul     r13
+	xor     r10d, r10d
+	mov     [r12+r9*8+8], rbp
+	add     rcx, rax
+	adc     rbx, rdx
+	mov     rax, [rsi+r9*8+8]
+	mov     [r12+r9*8+16], rcx
+	xor     ebp, ebp
+	mul     r13
+	add     rbx, rax
+	mov     rax, [rsi+r9*8+16]
+	adc     r10, rdx
+	xor     ecx, ecx
+	mul     r13
+	add     r10, rax
+	mov     rax, [rsi+r9*8+24]
+	adc     rbp, rdx
+	mov     [r12+r9*8+24], rbx
+	mul     r13
+	add     r9, 4
+	js      .13
+	add     rbp, rax
+	mov     [r12], r10
+	adc     rcx, rdx
+	mov     [r12+8], rbp
+	mov     [r12+16], rcx
+	lea		r12, [r12+16]
+	lea     rsi, [rsi-8]
+	jmp     L21
+
+L15:lea     r12, [rdi+r11*8+8]
+	mov     r13, [rsi]
+	mov     rax, [rsi+8]
+	lea     rsi, [rsi+r11*8+8]
+	lea     r8, [r11-5]
+	lea     r9, [r11-1]
+	neg     r9
+	mov     r14, rax
+	mul     r13
+	mov     r10, rdx
+	xor     ebx, ebx
+	xor     ecx, ecx
+	mov     [rdi+8], rax
+	jmp     .17
+
+	xalign  16
+.16:mul     r14
+	add     rbx, rax
+	adc     rcx, rdx
+	mov     rax, [rsi+r9*8-24]
+	mov     ebp, 0
+	mul     r13
+	add     rbx, rax
+	mov     rax, [rsi+r9*8-24]
+	adc     rcx, rdx
+	adc     ebp, 0
+	mul     r14
+	add     rcx, rax
+	mov     [r12+r9*8-24], rbx
+	adc     rbp, rdx
+	mov     rax, [rsi+r9*8-16]
+	mul     r13
+	mov     r10d, 0
+	add     rcx, rax
+	adc     rbp, rdx
+	mov     rax, [rsi+r9*8-16]
+	adc     r10d, 0
+	mov     ebx, 0
+	mov     [r12+r9*8-16], rcx
+	mul     r14
+	add     rbp, rax
+	mov     rax, [rsi+r9*8-8]
+	adc     r10, rdx
+	mov     ecx, 0
+	mul     r13
+	add     rbp, rax
+	mov     rax, [rsi+r9*8-8]
+	adc     r10, rdx
+	adc     ebx, 0
+	mul     r14
+	add     r10, rax
+	mov     [r12+r9*8-8], rbp
+	adc     rbx, rdx
+.17:mov     rax, [rsi+r9*8]
+	mul     r13
+	add     r10, rax
+	adc     rbx, rdx
+	adc     ecx, 0
+	add     r9, 4
+	mov     rax, [rsi+r9*8-32]
+	mov     [r12+r9*8-32], r10
+	js      .16
+	mul     r14
+	add     rbx, rax
+	adc     rcx, rdx
+	mov     [r12-8], rbx
+	mov     [r12], rcx
+	lea     rsi, [rsi-16]
+	jmp     L21
+L18:lea     r9, [r8+4]
+	neg     r9
+	mov     r13, [rsi+r9*8+16]
+	mov     r14, [rsi+r9*8+24]
+	mov     rax, [rsi+r9*8+24]
+	mul     r13
+	xor     r10d, r10d
+	add     [r12+r9*8+24], rax
+	adc     r10, rdx
+	xor     ebx, ebx
+	xor     ecx, ecx
+	jmp     .20
+
+	xalign  16
+.19:add     [r12+r9*8], r10
+	adc     rbx, rax
+	mov     rax, [rsi+r9*8+8]
+	adc     rcx, rdx
+	mov     ebp, 0
+	mul     r13
+	add     rbx, rax
+	mov     rax, [rsi+r9*8+8]
+	adc     rcx, rdx
+	adc     ebp, 0
+	mul     r14
+	add     [r12+r9*8+8], rbx
+	adc     rcx, rax
+	adc     rbp, rdx
+	mov     rax, [rsi+r9*8+16]
+	mov     r10d, 0
+	mul     r13
+	add     rcx, rax
+	mov     rax, [rsi+r9*8+16]
+	adc     rbp, rdx
+	adc     r10d, 0
+	mul     r14
+	add     [r12+r9*8+16], rcx
+	adc     rbp, rax
+	mov     rax, [rsi+r9*8+24]
+	adc     r10, rdx
+	mul     r13
+	mov     ebx, 0
+	add     rbp, rax
+	adc     r10, rdx
+	mov     ecx, 0
+	mov     rax, [rsi+r9*8+24]
+	adc     ebx, 0
+	mul     r14
+	add     [r12+r9*8+24], rbp
+	adc     r10, rax
+	adc     rbx, rdx
+.20:mov     rax, [rsi+r9*8+32]
+	mul     r13
+	add     r10, rax
+	mov     rax, [rsi+r9*8+32]
+	adc     rbx, rdx
+	adc     ecx, 0
+	mul     r14
+	add     r9, 4
+	js      .19
+	add     [r12], r10
+	adc     rbx, rax
+	adc     rcx, rdx
+	mov     [r12+8], rbx
+	mov     [r12+16], rcx
+	lea		r12, [r12+16]
+	add     r8d, -2
+L21:lea     r9, [r8+2]
+	neg     r9
+	mov     r13, [rsi+r9*8]
+	mov     r14, [rsi+r9*8+8]
+	mov     rax, [rsi+r9*8+8]
+	mul     r13
+	xor     ecx, ecx
+	add     [r12+r9*8+8], rax
+	adc     rcx, rdx
+	xor     ebp, ebp
+	jmp     .23
+
+	xalign  16
+.22:add     [r12+r9*8], r10
+	adc     rbx, rax
+	mov     rax, [rsi+r9*8+8]
+	adc     rcx, rdx
+	mov     ebp, 0
+	mul     r13
+	add     rbx, rax
+	mov     rax, [rsi+r9*8+8]
+	adc     rcx, rdx
+	adc     ebp, 0
+	mul     r14
+	add     [r12+r9*8+8], rbx
+	adc     rcx, rax
+	adc     rbp, rdx
+.23:mov     rax, [rsi+r9*8+16]
+	mov     r10d, 0
+	mul     r13
+	add     rcx, rax
+	mov     rax, [rsi+r9*8+16]
+	adc     rbp, rdx
+	adc     r10d, 0
+	mul     r14
+	add     [r12+r9*8+16], rcx
+	adc     rbp, rax
+	mov     rax, [rsi+r9*8+24]
+	adc     r10, rdx
+	mul     r13
+	mov     ebx, 0
+	add     rbp, rax
+	adc     r10, rdx
+	mov     ecx, 0
+	mov     rax, [rsi+r9*8+24]
+	adc     ebx, 0
+	mul     r14
+	add     [r12+r9*8+24], rbp
+	adc     r10, rax
+	adc     rbx, rdx
+	mov     rax, [rsi+r9*8+32]
+	mul     r13
+	add     r10, rax
+	mov     rax, [rsi+r9*8+32]
+	adc     rbx, rdx
+	adc     ecx, 0
+	mul     r14
+	add     r9, 4
+	js      .22
+	add     [r12], r10
+	adc     rbx, rax
+	adc     rcx, rdx
+	mov     [r12+8], rbx
+	mov     [r12+16], rcx
+	lea		r12, [r12+16]
+L24:add     r8d, -2
+	jne     L18
+	mov     r13, [rsi-16]
+	mov     r14, [rsi-8]
+	mov     rax, [rsi-8]
+	mul     r13
+	xor     r10d, r10d
+	add     [r12-8], rax
+	adc     r10, rdx
+	xor     ebx, ebx
+	xor     ecx, ecx
+	mov     rax, [rsi]
+	mul     r13
+	add     r10, rax
+	mov     rax, [rsi]
+	adc     rbx, rdx
+	mul     r14
+	add     [r12], r10
+	adc     rbx, rax
+	adc     rcx, rdx
+	mov     [r12+8], rbx
+	mov     [r12+16], rcx
+	lea     r9, [r11+r11-4]
+	mov     r11, [rdi+8]
+	lea     rsi, [rsi-8]
+	lea     rdi, [rdi+r9*8]
+	neg     r9
+	mov     rax, [rsi+r9*4]
+	mul     rax
+	test    r9b, 2
+	jnz     .26
+.25:add     r11, r11
+	sbb     ebx, ebx
+	add     r11, rdx
+	mov     [rdi+r9*8], rax
+	jmp     .28
+.26:add     r11, r11
+	sbb     ebp, ebp
+	add     r11, rdx
+	mov     [rdi+r9*8], rax
+	lea     r9, [r9-2]
+	jmp     .29
+
+	xalign  16
+.27:mov     rax, [rsi+r9*4]
+	mul     rax
+	add     ebp, ebp
+	adc     r10, rax
+	adc     r11, rdx
+	mov     [rdi+r9*8], r10
+.28:mov     [rdi+r9*8+8], r11
+	mov     r10, [rdi+r9*8+16]
+	adc     r10, r10
+	mov     r11, [rdi+r9*8+24]
+	adc     r11, r11
+	nop
+	sbb     ebp, ebp
+	mov     rax, [rsi+r9*4+8]
+	mul     rax
+	add     ebx, ebx
+	adc     r10, rax
+	adc     r11, rdx
+	mov     [rdi+r9*8+16], r10
+.29:mov     [rdi+r9*8+24], r11
+	mov     r10, [rdi+r9*8+32]
+	adc     r10, r10
+	mov     r11, [rdi+r9*8+40]
+	adc     r11, r11
+	sbb     ebx, ebx
+	add     r9, 4
+	js      .27
+	mov     rax, [rsi]
+	mul     rax
+	add     ebp, ebp
+	adc     r10, rax
+	adc     r11, rdx
+	mov     [rdi], r10
+	mov     [rdi+8], r11
+	mov     r10, [rdi+16]
+	adc     r10, r10
+	sbb     ebp, ebp
+	neg     ebp
+	mov     rax, [rsi+8]
+	mul     rax
+	add     ebx, ebx
+	adc     r10, rax
+	adc     rdx, rbp
+	mov     [rdi+16], r10
+	mov     [rdi+24], rdx
+	WIN64_GCC_END
+
+	end

--- a/SMP/yasm/sub_err1_n.asm
+++ b/SMP/yasm/sub_err1_n.asm
@@ -1,0 +1,104 @@
+; PROLOGUE(mpn_sub_err1_n)
+
+;  Copyright (C) 2009, David Harvey
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  All rights reserved.
+;
+;  Redistribution and use in source and binary forms, with or without
+;  modification, are permitted provided that the following conditions are
+;  met:
+;  1. Redistributions of source code must retain the above copyright notice,
+;  this list of conditions and the following disclaimer.
+;
+;  2. Redistributions in binary form must reproduce the above copyright
+;  notice, this list of conditions and the following disclaimer in the
+;  documentation and/or other materials provided with the distribution.
+;
+;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+;  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;  HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+;  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+;  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;
+;  mp_limb_t mpn_add_err1_n(mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  mp_limb_t mpn_sub_err1_n(mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_size_t, mp_limb_t)
+;  rax                         rdi     rsi     rdx     rcx       r8        r9     8(rsp)
+;  rax                         rcx     rdx      r8      r9 [rsp+40]  [rsp+48]   [rsp+56]
+
+%include "yasm_mac.inc"
+
+%define reg_save_list   rbx, rsi, rdi, rbp, r12
+
+%macro fun 2
+	xalign  16
+    FRAME_PROC %1, 0, reg_save_list
+    mov     rax, qword [rsp+stack_use+48]
+    lea     rdi, [rcx+rax*8]
+    lea     rsi, [rdx+rax*8]
+    lea     rdx, [r8+rax*8]
+    mov     rcx, r9
+    mov     r9, rax
+    mov     r8, [rsp+stack_use+40]
+    mov     rax, [rsp+stack_use+56]
+    
+	xor     rbx, rbx
+	xor     rbp, rbp
+	test    r9, 1
+	jnz     %%2
+%%1:lea     r8, [r8+r9*8-8]
+	neg     r9
+	jmp     %%3
+
+	xalign  16
+%%2:lea     r8, [r8+r9*8-16]
+	neg     r9
+	shr     rax, 1
+	mov     r12, [rsi+r9*8]
+	%2      r12, [rdx+r9*8]
+	cmovc   rbx, [r8+8]
+	mov     [rdi+r9*8], r12
+	setc    al
+	inc     r9
+	jz      %%4
+
+	xalign  16
+%%3:mov     r12, [rsi+r9*8]
+	shr     rax, 1
+	%2      r12, [rdx+r9*8]
+	mov     r11, 0
+	mov     [rdi+r9*8], r12
+	mov     r10, 0
+	mov     r12, [rsi+r9*8+8]
+	cmovc   r10, [r8]
+	%2      r12, [rdx+r9*8+8]
+	cmovc   r11, [r8-8]
+	setc    al
+	add     rbx, r10
+	adc     rbp, 0
+	add     rbx, r11
+	mov     [rdi+r9*8+8], r12
+	adc     rbp, 0
+	add     r9, 2
+	lea     r8, [r8-16]
+	jnz     %%3
+%%4:mov     [rcx], rbx
+	mov     [rcx+8], rbp
+    END_PROC reg_save_list
+%endmacro
+
+
+    CPU  Athlon64
+    BITS 64
+;		global __gmpn_sub_err1_n
+
+    fun mpn_sub_err1_n, sbb
+    
+    end

--- a/SMP/yasm/sub_err2_n.asm
+++ b/SMP/yasm/sub_err2_n.asm
@@ -1,0 +1,123 @@
+; PROLOGUE(mpn_sub_err2_n)
+;
+;  AMD64 mpn_add_err2_n, mpn_sub_err2_n
+;
+;  Copyright (C) 2009, David Harvey
+;
+;  Windows Conversion Copyright 2008 Brian Gladman
+;
+;  All rights reserved.
+;
+;  Redistribution and use in source and binary forms, with or without
+;  modification, are permitted provided that the following conditions are
+;  met:
+;
+;  1. Redistributions of source code must retain the above copyright notice,
+;  this list of conditions and the following disclaimer.
+;
+;  2. Redistributions in binary form must reproduce the above copyright
+;  notice, this list of conditions and the following disclaimer in the
+;  documentation and/or other materials provided with the distribution.
+;
+;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+;  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;  HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+;  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+;  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;
+;  mp_limb_t mpn_add_err2_n (mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr,  mp_ptr, mp_size_t, mp_limb_t);
+;  mp_limb_t mpn_sub_err2_n (mp_ptr, mp_ptr, mp_ptr, mp_ptr, mp_ptr,  mp_ptr, mp_size_t, mp_limb_t);
+;  rax                          rdi     rsi     rdx     rcx       r8      r9     8(rsp)    16(rsp)
+;  rax                          rcx     rdx      r8      r9 [rsp+40] [rsp+48]  [rsp+56]   [rsp+64]
+
+%include "yasm_mac.inc"
+
+%define reg_save_list   rbx, rsi, rdi, rbp, r12, r13, r14
+
+%macro fun 2
+	xalign  16
+    FRAME_PROC %1, 0, reg_save_list
+    mov     rax, qword [rsp+stack_use+56]
+    lea     rdi, [rcx+rax*8]
+    lea     rsi, [rdx+rax*8]
+    lea     rdx, [r8+rax*8]
+    mov     rcx, r9
+    mov     r10, rax
+    mov     r8, [rsp+stack_use+40]
+    mov     r9, [rsp+stack_use+48]
+    mov     rax, [rsp+stack_use+64]
+    
+	xor     rbp, rbp
+	xor     r11, r11
+	xor     r12, r12
+	xor     r13, r13
+	sub     r9, r8
+	test    r10, 1
+	jnz     %%1
+	lea     r8, [r8+r10*8-8]
+	neg     r10
+	jmp     %%2
+
+	xalign  16
+%%1:lea     r8, [r8+r10*8-16]
+	neg     r10
+	shr     rax, 1
+	mov     rbx, [rsi+r10*8]
+	%2      rbx, [rdx+r10*8]
+	cmovc   rbp, [r8+8]
+	cmovc   r12, [r8+r9+8]
+	mov     [rdi+r10*8], rbx
+	sbb     rax, rax
+	inc     r10
+	jz      %%3
+
+	xalign  16
+%%2:mov     rbx, [rsi+r10*8]
+	shr     rax, 1
+	%2      rbx, [rdx+r10*8]
+	mov     [rdi+r10*8], rbx
+	sbb     r14, r14
+	mov     rbx, [rsi+r10*8+8]
+	%2      rbx, [rdx+r10*8+8]
+	mov     [rdi+r10*8+8], rbx
+	sbb     rax, rax
+    mov     rbx, [r8]
+	and     rbx, r14
+	add     rbp, rbx
+	adc     r11, 0
+    and     r14, [r8+r9]
+	add     r12, r14
+	adc     r13, 0
+    mov     rbx, [r8-8]
+	and     rbx, rax
+	add     rbp, rbx
+	adc     r11, 0
+    mov     rbx, [r8+r9-8]
+	and     rbx, rax
+	add     r12, rbx
+	adc     r13, 0
+	add     r10, 2
+	lea     r8, [r8-16]
+	jnz     %%2
+%%3:mov     [rcx], rbp
+	mov     [rcx+8], r11
+	mov     [rcx+16], r12
+	mov     [rcx+24], r13
+	and     eax, 1
+    END_PROC reg_save_list
+%endmacro
+
+
+    CPU  Athlon64
+    BITS 64
+;		global __gmpn_sub_err2_n
+
+    fun mpn_sub_err2_n, sbb
+    
+    end

--- a/SMP/yasm/udiv_qrnnd.asm
+++ b/SMP/yasm/udiv_qrnnd.asm
@@ -1,0 +1,36 @@
+; PROLOGUE(mpn_udiv_qrnnd)
+
+;  Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or
+;  modify it under the terms of the GNU Lesser General Public License as
+;  published by the Free Software Foundation; either version 2.1 of the
+;  License, or (at your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;  Lesser General Public License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public
+;  License along with the MPIR Library; see the file COPYING.LIB.  If
+;  not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+;  Fifth Floor, Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_udiv_qrnnd(mp_ptr, mp_limb_t, mp_limb_t, mp_limb_t)
+;  rax                         rdi        rsi        rdx        rcx
+;  rax                         rcx        rdx         r8         r9
+
+%include "yasm_mac.inc"
+
+    BITS 64
+
+    LEAF_PROC mpn_udiv_qrnnd
+    mov     rax,r8
+    div     r9
+    mov     [rcx],rdx
+    ret
+
+    end

--- a/SMP/yasm/umul_ppmm.asm
+++ b/SMP/yasm/umul_ppmm.asm
@@ -1,0 +1,37 @@
+; PROLOGUE(mpn_umul_ppmm)
+
+;  Copyright 2008 Brian Gladman
+;
+;  This file is part of the MPIR Library.
+;
+;  The MPIR Library is free software; you can redistribute it and/or
+;  modify it under the terms of the GNU Lesser General Public License as
+;  published by the Free Software Foundation; either version 2.1 of the
+;  License, or (at your option) any later version.
+;
+;  The MPIR Library is distributed in the hope that it will be useful,
+;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;  Lesser General Public License for more details.
+;
+;  You should have received a copy of the GNU Lesser General Public
+;  License along with the MPIR Library; see the file COPYING.LIB.  If
+;  not, write to the Free Software Foundation, Inc., 51 Franklin Street,
+;  Fifth Floor, Boston, MA 02110-1301, USA.
+;
+;  mp_limb_t mpn_umul_ppmm(mp_ptr, mp_limb_t, mp_limb_t)
+;  rax                        rdi        rsi        rdx
+;  rax                        rcx        rdx         r8
+
+%include "yasm_mac.inc"
+
+    BITS 64
+
+    LEAF_PROC mpn_umul_ppmm
+    mov     rax,rdx
+    mul     r8
+    mov     [rcx],rax
+    mov     rax,rdx
+    ret
+
+    end

--- a/SMP/yasm/vsyasm.props
+++ b/SMP/yasm/vsyasm.props
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup
+    Condition="'$(YASMBeforeTargets)' == '' and '$(YASMAfterTargets)' == '' and '$(ConfigurationType)' != 'Makefile'">
+    <YASMBeforeTargets>Midl</YASMBeforeTargets>
+    <YASMAfterTargets>CustomBuild</YASMAfterTargets>
+  </PropertyGroup>
+  <PropertyGroup>
+    <YASMDependsOn
+      Condition="'$(ConfigurationType)' != 'Makefile'">_SelectedFiles;$(YASMDependsOn)</YASMDependsOn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <YasmPath Condition= "'$(YASMPATH)' == ''">$(VCInstallDir)bin\</YasmPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <YASM>
+      <Debug>False</Debug>
+      <ObjectFile>$(IntDir)</ObjectFile>
+      <PreProc>0</PreProc>
+      <Parser>0</Parser>
+      <CommandLineTemplate>"$(YasmPath)"vsyasm.exe -Xvc -f $(Platform) [AllOptions] [AdditionalOptions] [Inputs]</CommandLineTemplate>
+      <Outputs>%(ObjectFile)</Outputs>
+      <ExecutionDescription>Assembling %(Filename)%(Extension)</ExecutionDescription>
+      <ShowOnlyRuleProperties>false</ShowOnlyRuleProperties>
+    </YASM>
+  </ItemDefinitionGroup>
+</Project>

--- a/SMP/yasm/vsyasm.targets
+++ b/SMP/yasm/vsyasm.targets
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PropertyPageSchema
+      Include="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).xml" />
+    <AvailableItemName
+      Include="YASM">
+      <Targets>_YASM</Targets>
+    </AvailableItemName>
+  </ItemGroup>
+  <UsingTask
+    TaskName="YASM"
+    TaskFactory="XamlTaskFactory"
+    AssemblyName="Microsoft.Build.Tasks.v4.0">
+    <Task>$(MSBuildThisFileDirectory)$(MSBuildThisFileName).xml</Task>
+  </UsingTask>
+  <Target
+    Name="_YASM"
+    BeforeTargets="$(YASMBeforeTargets)"
+    AfterTargets="$(YASMAfterTargets)"
+    Condition="'@(YASM)' != ''"
+    DependsOnTargets="$(YASMDependsOn);ComputeYASMOutput"
+    Outputs="@(YASM->'%(ObjectFile)')"
+    Inputs="@(YASM);%(YASM.AdditionalDependencies);$(MSBuildProjectFile)">
+    <ItemGroup
+      Condition="'@(SelectedFiles)' != ''">
+      <YASM
+        Remove="@(YASM)"
+        Condition="'%(Identity)' != '@(SelectedFiles)'" />
+    </ItemGroup>
+    <ItemGroup>
+      <YASM_tlog
+        Include="%(YASM.ObjectFile)"
+        Condition="'%(YASM.ObjectFile)' != '' and '%(YASM.ExcludedFromBuild)' != 'true'">
+        <Source>@(YASM, '|')</Source>
+      </YASM_tlog>
+    </ItemGroup>
+    <Message
+      Importance="High"
+      Text="%(YASM.ExecutionDescription)" />
+    <WriteLinesToFile
+      Condition="'@(YASM_tlog)' != '' and '%(YASM_tlog.ExcludedFromBuild)' != 'true'"
+      File="$(IntDir)$(ProjectName).write.1.tlog"
+      Lines="^%(YASM_tlog.Source);@(YASM_tlog->'%(Fullpath)')" />
+    <YASM
+      Condition="'@(YASM)' != '' and '%(YASM.ExcludedFromBuild)' != 'true'"
+      CommandLineTemplate="%(YASM.CommandLineTemplate)"
+      Debug="%(YASM.Debug)"
+      PreIncludeFile="%(YASM.PreIncludeFile)"
+      IncludePaths="%(YASM.IncludePaths)"
+      Defines="%(YASM.Defines)"
+      UnDefines="%(YASM.UnDefines)"
+      ObjectFile="%(YASM.ObjectFile)"
+      ListFile="%(YASM.ListFile)"
+      MapFile="%(YASM.MapFile)"
+      ErrorFile="%(YASM.ErrorFile)"
+      SymbolPrefix="%(YASM.SymbolPrefix)"
+      SymbolSuffix="%(YASM.SymbolSuffix)"
+      PreProc="%(YASM.PreProc)"
+      Parser="%(YASM.Parser)"
+      AdditionalOptions="%(YASM.AdditionalOptions)"
+      Inputs="@(YASM)" />
+  </Target>
+  <PropertyGroup>
+    <ComputeLinkInputsTargets>
+            $(ComputeLinkInputsTargets);
+            ComputeYASMOutput;
+          </ComputeLinkInputsTargets>
+    <ComputeLibInputsTargets>
+            $(ComputeLibInputsTargets);
+            ComputeYASMOutput;
+          </ComputeLibInputsTargets>
+  </PropertyGroup>
+  <Target
+    Name="ComputeYASMOutput"
+    Condition="'@(YASM)' != ''">
+    <ItemGroup>
+      <YASMDirsToMake
+        Condition="'@(YASM)' != '' and '%(YASM.ExcludedFromBuild)' != 'true' and !HasTrailingSlash('%(YASM.ObjectFile)')"
+        Include="%(YASM.ObjectFile)" />
+      <Link
+        Include="%(YASMDirsToMake.Identity)"
+        Condition="'%(Extension)'=='.obj' or '%(Extension)'=='.res' or '%(Extension)'=='.rsc' or '%(Extension)'=='.lib'" />
+      <Lib
+        Include="%(YASMDirsToMake.Identity)"
+        Condition="'%(Extension)'=='.obj' or '%(Extension)'=='.res' or '%(Extension)'=='.rsc' or '%(Extension)'=='.lib'" />
+      <ImpLib
+        Include="%(YASMDirsToMake.Identity)"
+        Condition="'%(Extension)'=='.obj' or '%(Extension)'=='.res' or '%(Extension)'=='.rsc' or '%(Extension)'=='.lib'" />
+    </ItemGroup>
+    <ItemGroup>
+      <YASMDirsToMake
+        Condition="'@(YASM)' != '' and '%(YASM.ExcludedFromBuild)' != 'true' and HasTrailingSlash('%(YASM.ObjectFile)')"
+        Include="@(YASM->'%(ObjectFile)%(Filename).obj')" />
+      <Link
+        Include="%(YASMDirsToMake.Identity)"
+        Condition="'%(Extension)'=='.obj' or '%(Extension)'=='.res' or '%(Extension)'=='.rsc' or '%(Extension)'=='.lib'" />
+      <Lib
+        Include="%(YASMDirsToMake.Identity)"
+        Condition="'%(Extension)'=='.obj' or '%(Extension)'=='.res' or '%(Extension)'=='.rsc' or '%(Extension)'=='.lib'" />
+      <ImpLib
+        Include="%(YASMDirsToMake.Identity)"
+        Condition="'%(Extension)'=='.obj' or '%(Extension)'=='.res' or '%(Extension)'=='.rsc' or '%(Extension)'=='.lib'" />
+    </ItemGroup>
+    <MakeDir
+      Directories="@(YASMDirsToMake->'%(RootDir)%(Directory)')" />
+  </Target>
+</Project>

--- a/SMP/yasm/vsyasm.xml
+++ b/SMP/yasm/vsyasm.xml
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ProjectSchemaDefinitions xmlns="clr-namespace:Microsoft.Build.Framework.XamlTypes;assembly=Microsoft.Build.Framework" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:sys="clr-namespace:System;assembly=mscorlib" xmlns:transformCallback="Microsoft.Cpp.Dev10.ConvertPropertyCallback">
+  <Rule
+    Name="YASM"
+    PageTemplate="tool"
+    DisplayName="Yasm Assembler"
+    Order="200">
+      
+    <Rule.DataSource>
+      <DataSource
+        Persistence="ProjectFile"
+        ItemType="YASM" />
+    </Rule.DataSource>
+      
+    <Rule.Categories>
+        
+      <Category
+        Name="General">
+        <Category.DisplayName>
+          <sys:String>General</sys:String>
+        </Category.DisplayName>
+      </Category>
+
+      <Category
+        Name="Symbols">
+          <Category.DisplayName>
+              <sys:String>Symbols</sys:String>
+          </Category.DisplayName>
+      </Category>
+
+      <Category
+        Name="Files">
+          <Category.DisplayName>
+              <sys:String>Files</sys:String>
+          </Category.DisplayName>
+      </Category>
+        
+      <Category
+        Name="Command Line"
+        Subtype="CommandLine">
+        <Category.DisplayName>
+          <sys:String>Command Line</sys:String>
+        </Category.DisplayName>
+      </Category>
+        
+    </Rule.Categories>
+
+    <StringListProperty
+      Name="Inputs"
+      Category="Command Line"
+      IsRequired="true"
+      Switch=" ">
+      <StringListProperty.DataSource>
+        <DataSource
+          Persistence="ProjectFile"
+          ItemType="YASM"
+          SourceType="Item" />
+      </StringListProperty.DataSource>
+    </StringListProperty>
+    
+    <BoolProperty
+      Name="Debug"
+      Subcategory="Configuration"
+      HelpContext="0"
+      DisplayName="Debug Information"
+      Description="Generate debugging information"
+      Switch="-g cv8" />
+
+    <StringListProperty
+      Name="IncludePaths"
+      Subcategory="Configuration"
+      HelpContext="0"
+      DisplayName="Include Paths"
+      Description="Set the paths for any additional include files"
+      Switch="-i &quot;[value]&quot;" />
+
+    <StringListProperty
+      Name="Defines"
+      Category="Symbols"
+      Subcategory="Pre-Defined Symbols"
+      HelpContext="0"
+      DisplayName="Defined Symbols"
+      Description="Specify pre-defined symbols ('symbol' or 'symbol = value') "
+      Switch="-d &quot;[value]&quot;" />
+    
+    <StringListProperty
+      Name="UnDefines"
+      Category="Symbols"
+      Subcategory="Pre-Defined Symbols"
+      HelpContext="0"
+      DisplayName="Remove Symbols"
+      Description="Remove pre-defined symbols "
+      Switch="-u &quot;[value]&quot;" />
+    
+    <StringProperty
+      Name="ObjectFile"
+      Subcategory="Output"
+      HelpContext="0"
+      DisplayName="Object File Name"
+      Description="Select the output file name"
+      Switch="-o &quot;[value]&quot;" />
+    
+    <StringProperty
+      Name="ListFile"
+      Category="Files"
+      Subcategory="Output"
+      HelpContext="0"
+      DisplayName="List File Name"
+      Description="Select an output listing by setting its file name"
+      Switch="-l &quot;[value]&quot;" />
+    
+    <StringProperty
+      Name="PreIncludeFile"
+      Category="Files"
+      Subcategory="Configuration"
+      HelpContext="0"
+      DisplayName="Pre Include File"
+      Description="Select a pre-included file by setting its name"
+      Switch="-P &quot;[value]&quot;" />
+      
+    <StringProperty
+      Name="MapFile"
+      Category="Files"
+      Subcategory="Output"
+      HelpContext="0"
+      DisplayName="Map File Name"
+      Description="Select a map output by setting its file name"
+      Switch="--mapdir= &quot;[value]&quot;" />
+
+    <StringProperty
+      Name="ErrorFile"
+      Category="Files"
+      Subcategory="Output"
+      HelpContext="0"
+      DisplayName="Error File Name"
+      Description="Send error/warning messages to a file by setting its name"
+      Switch="-E &quot;[value]&quot;" />
+
+    <StringProperty
+      Name="SymbolPrefix"
+      Category="Symbols"
+      Subcategory="Symbols"
+      HelpContext="0"
+      DisplayName="External Symbol Prefix"
+      Description="Prepend symbol to all external symbols"
+      Switch="--prefix &quot;[value]&quot;" />
+
+    <StringProperty
+      Name="SymbolSuffix"
+      Category="Symbols"
+      Subcategory="Symbols"
+      HelpContext="0"
+      DisplayName="External Symbol Suffix"
+      Description="Append symbol to all external symbols"
+      Switch="--suffix &quot;[value]&quot;" />
+
+    <EnumProperty
+      Name="PreProc"
+      Subcategory="Configuration"
+      HelpContext="0"
+      DisplayName="Pre-Processor"
+      Description="Select the pre-processor ('nasm' or 'raw')">
+      <EnumValue
+        Name="0"
+        DisplayName="Nasm "
+        Switch="-rnasm" />
+      <EnumValue
+        Name="1"
+        DisplayName="Raw"
+        Switch="-rraw" />
+    </EnumProperty>
+    
+    <EnumProperty
+      Name="Parser"
+      Subcategory="Configuration"
+      HelpContext="0"
+      DisplayName="Parser"
+      Description="Select the parser for Intel ('nasm') or AT&amp;T ( 'gas') syntax">
+      <EnumValue
+        Name="0"
+        DisplayName="Nasm"
+        Switch="-pnasm" />
+      <EnumValue
+        Name="1"
+        DisplayName="Gas"
+        Switch="-pgas" />
+    </EnumProperty>
+    
+    <StringProperty
+      Name="CommandLineTemplate"
+      DisplayName="Command Line"
+      Visible="False"
+      IncludeInCommandLine="False" />
+    
+    <DynamicEnumProperty
+      Name="YASMBeforeTargets"
+      Category="General"
+      EnumProvider="Targets"
+      IncludeInCommandLine="False">
+      <DynamicEnumProperty.DisplayName>
+        <sys:String>Execute Before</sys:String>
+      </DynamicEnumProperty.DisplayName>
+      <DynamicEnumProperty.Description>
+        <sys:String>Specifies the targets for the build customization to run before.</sys:String>
+      </DynamicEnumProperty.Description>
+      <DynamicEnumProperty.ProviderSettings>
+        <NameValuePair
+          Name="Exclude"
+          Value="^YASMBeforeTargets|^Compute" />
+      </DynamicEnumProperty.ProviderSettings>
+      <DynamicEnumProperty.DataSource>
+        <DataSource
+          Persistence="ProjectFile"
+          HasConfigurationCondition="true" />
+      </DynamicEnumProperty.DataSource>
+    </DynamicEnumProperty>
+    
+    <DynamicEnumProperty
+      Name="YASMAfterTargets"
+      Category="General"
+      EnumProvider="Targets"
+      IncludeInCommandLine="False">
+      <DynamicEnumProperty.DisplayName>
+        <sys:String>Execute After</sys:String>
+      </DynamicEnumProperty.DisplayName>
+      <DynamicEnumProperty.Description>
+        <sys:String>Specifies the targets for the build customization to run after.</sys:String>
+      </DynamicEnumProperty.Description>
+      <DynamicEnumProperty.ProviderSettings>
+        <NameValuePair
+          Name="Exclude"
+          Value="^YASMAfterTargets|^Compute" />
+      </DynamicEnumProperty.ProviderSettings>
+      <DynamicEnumProperty.DataSource>
+        <DataSource
+          Persistence="ProjectFile"
+          ItemType=""
+          HasConfigurationCondition="true" />
+      </DynamicEnumProperty.DataSource>
+    </DynamicEnumProperty>
+    
+    <StringListProperty
+      Name="Outputs"
+      DisplayName="Outputs"
+      Visible="False"
+      IncludeInCommandLine="False" />
+    
+    <StringProperty
+      Name="ExecutionDescription"
+      DisplayName="Execution Description"
+      Visible="False"
+      IncludeInCommandLine="False" />
+    
+    <StringListProperty
+      Name="AdditionalDependencies"
+      DisplayName="Additional Dependencies"
+      IncludeInCommandLine="False"
+      Visible="true" />
+    
+    <StringProperty
+      Subtype="AdditionalOptions"
+      Name="AdditionalOptions"
+      Category="Command Line">
+      <StringProperty.DisplayName>
+        <sys:String>Additional Options</sys:String>
+      </StringProperty.DisplayName>
+      <StringProperty.Description>
+        <sys:String>Additional Options</sys:String>
+      </StringProperty.Description>
+    </StringProperty>
+  </Rule>
+  
+  <ItemType
+    Name="YASM"
+    DisplayName="Yasm Assembler" />
+  <FileExtension
+    Name="*.asm"
+    ContentType="YASM" />
+  <ContentType
+    Name="YASM"
+    DisplayName="Yasm Assembler"
+    ItemType="YASM" />
+</ProjectSchemaDefinitions>

--- a/SMP/yasm/yasm_mac.inc
+++ b/SMP/yasm/yasm_mac.inc
@@ -1,0 +1,279 @@
+;  Copyright (C) 2009, 2008 Brian Gladman
+;
+;  All rights reserved.
+;
+;  Redistribution and use in source and binary forms, with or without
+;  modification, are permitted provided that the following conditions are
+;  met:
+;  1. Redistributions of source code must retain the above copyright notice,
+;  this list of conditions and the following disclaimer.
+;
+;  2. Redistributions in binary form must reproduce the above copyright
+;  notice, this list of conditions and the following disclaimer in the
+;  documentation and/or other materials provided with the distribution.
+;
+;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;  ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+;  PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;  HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+;  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+;  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;
+
+; Standardised register numbering scheme
+
+%define r0  rax
+%define r1  rdx
+%define r2  rcx
+%define r3  rbx
+%define r4  rsi
+%define r5  rdi
+%define r6  rbp
+%define r7  rsp
+
+%define r0d eax
+%define r1d edx
+%define r2d ecx
+%define r3d ebx
+%define r4d esi
+%define r5d edi
+%define r6d ebp
+%define r7d esp
+
+%define r0w ax
+%define r1w dx
+%define r2w cx
+%define r3w bx
+%define r4w si
+%define r5w di
+%define r6w bp
+%define r7w sp
+
+%define r0b al
+%define r1b dl
+%define r2b cl
+%define r3b bl
+%define r4b sil
+%define r5b dil
+%define r6b bpl
+%define r7b spl
+
+; Standard macro for alignment (used to allow easy subsititution of
+; alternative padding schemes)
+
+%macro xalign 1
+    align %1
+%endmacro
+
+; YASM macros for handling Windows Prologues and Epilogues
+;
+; Copyright 2008, 2009 Brian Gladman
+;
+; Windows x64 prologue macro
+;
+;   FRAME_PROC name, stack_slots, register_save_list 
+;
+;   name:                routine name
+;   register_save_list:  comma separated list of registers to save
+;   stack_slots:         stack space needed in 8 byte units
+
+; Windows x64 epilogue macro
+;
+;   EXIT_PROC register_save_list
+;
+;   register_save_list:  comma separated list of registers to save
+;                        in same order used in prologue
+;
+; On return the macro variable 'stack_use' gives the total number 
+; of bytes used on the stack. This allows the function parameters
+; to be accessed at [rsp + stack_use + 8 * n] where n starts at 1
+; (for n = 1..4 this is shadow space for a register parameter)  
+;
+; Windows x64 epilogue and end procedure macro
+;
+;   END_PROC register_save_list
+;
+; Details as above but used at the end of a procedure to signal 
+; the end of its source code.
+
+%macro FRAME_PROC 2-*
+
+    global  __g%1
+    
+%ifdef DLL
+    export  __g%1
+%endif
+
+    PROC_FRAME __g%1
+    %rotate 1
+      
+    %if %1 < 0
+        %error Negative stack allocation not allowed
+    %else
+        %if (%0 & 1) == (%1 & 1)
+            %assign stack_use 8 * (%1 + 1)
+        %else
+            %assign stack_use 8 * %1
+        %endif
+    %endif
+    %rotate 1
+
+    %if %0 > 2
+        %rep %0 - 2
+            push_reg  %1
+            %rotate 1
+        %endrep
+    %endif
+
+    %if stack_use > 0
+        alloc_stack stack_use
+    %endif
+    
+    %assign stack_use stack_use + 8 * (%0 - 2)
+    END_PROLOGUE
+
+%endmacro
+
+%macro EXIT_PROC 0-*
+
+    add rsp, stack_use - 8 * %0
+    %if %0 > 0
+        %rep %0
+            %rotate -1
+            pop  %1  
+        %endrep
+    %endif
+    ret
+
+%endmacro
+
+%macro END_PROC 0-*
+
+    add rsp, stack_use - 8 * %0
+    %if %0 > 0
+        %rep %0
+            %rotate -1
+            pop  %1  
+        %endrep
+    %endif
+    ret
+    ENDPROC_FRAME
+
+%endmacro
+
+%macro LEAF_PROC 1
+    
+    global  __g%1
+    
+%ifdef DLL
+    export  __g%1
+%endif
+
+__g%1:
+
+%endmacro
+
+; Macros for using assembler code using the GCC Calling
+; Conventions in Windows.  These macros move the first
+; six integer parameters from Microsoft ABI calling
+; calling conventions to those used by GCC: 
+;
+;   function(     MSVC --> GCC
+;       p1,       rcx      rdi
+;       p2,       rdx      rsi
+;       p3,        r8      rdx
+;       p4,        r9      rcx
+;       p5,  [rsp+40]       r8
+;       p6,  [rsp+48]       r9
+;
+;   WIN64_GCC_PROC name, n_parms, (frame | leaf)
+;
+;   WIN64_GCC_EXIT frame | leaf
+;
+;   WIN64_GCC_END  frame | leaf
+; 
+;     name    subroutine name
+;     n_parms number of parameters (default 6)
+;     type    frame or leaf function (default frame)
+;
+; These defines are also used:
+;
+;     reg_save_list   list of registers to be saved
+;                     and restored
+;     stack_slots     number of 8 byte slots needed
+;                     on the stack (excluding the 
+;                     register save/restore space)
+
+%macro WIN64_GCC_PROC 1-3 6, frame
+
+    %ifidn %3, frame
+
+        %ifndef reg_save_list
+            %define reg_save_list rsi, rdi
+        %endif
+
+        %ifndef stack_slots
+            %define stack_slots 0
+        %endif
+
+        FRAME_PROC %1, stack_slots, reg_save_list
+        
+    %elifidn %3, leaf
+
+        LEAF_PROC %1
+
+    %else
+
+        %error no (or wrong) function type defined 
+
+    %endif
+
+        %if %2 > 0
+            mov     rdi, rcx
+        %endif
+        %if %2 > 1
+            mov     rsi, rdx
+        %endif
+        %if %2 > 2
+            mov     rdx, r8
+        %endif
+        %if %2 > 3
+            mov     rcx, r9
+        %endif
+        %if %2 > 4
+            mov     r8, [rsp + stack_use + 40]
+        %endif
+        %if %2 > 5
+            mov     r9, [rsp + stack_use + 48]
+        %endif
+        
+%endmacro
+
+%macro WIN64_GCC_EXIT 0-1 frame
+
+    %ifidn %1, frame
+        EXIT_PROC reg_save_list
+    %elifidn %1, leaf
+        ret
+    %else
+        %error no (or wrong) function type defined 
+    %endif
+
+%endmacro
+
+%macro WIN64_GCC_END 0-1 frame
+
+    %ifidn %1, frame
+        END_PROC reg_save_list
+    %elifidn %1, leaf
+        ret
+    %else
+        %error no (or wrong) function type defined 
+    %endif
+
+%endmacro

--- a/gmp-chudnovsky.c
+++ b/gmp-chudnovsky.c
@@ -1,0 +1,765 @@
+/* Pi computation using Chudnovsky's algortithm.
+
+* Copyright 2002, 2005 Hanhong Xue (macroxue at yahoo dot com)
+
+* Slightly modified 2005 by Torbjorn Granlund to allow more than 2G
+digits to be computed.
+
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* 1. Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+* EVENT SHALL THE AUTHORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+* PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+* OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+* OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+* ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <gmp.h>
+
+#define A   13591409
+#define B   545140134
+#define C   640320
+#define D   12
+
+#define BITS_PER_DIGIT   3.32192809488736234787
+#define DIGITS_PER_ITER  14.1816474627254776555
+#define DOUBLE_PREC      53
+
+#ifdef __GNUC__
+#define inline __inline__
+#endif
+
+char *prog_name;
+
+#if CHECK_MEMUSAGE
+#undef CHECK_MEMUSAGE
+#define CHECK_MEMUSAGE							\
+  do {									\
+    char buf[100];							\
+    snprintf (buf, 100,							\
+	      "ps aguxw | grep '[%c]%s'", prog_name[0], prog_name+1);	\
+    system (buf);							\
+  } while (0)
+#else
+#undef CHECK_MEMUSAGE
+#define CHECK_MEMUSAGE
+#endif
+
+
+/* Return user CPU time measured in milliseconds.  */
+
+#if !defined (__sun) \
+    && (defined (USG) || defined (__SVR4) || defined (_UNICOS) \
+	|| defined (__hpux)) || defined (_MSC_VER)
+int
+cputime()
+{
+	return (int)((double)clock() * 1000 / CLOCKS_PER_SEC);
+}
+#else
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+int
+cputime()
+{
+	struct rusage rus;
+
+	getrusage(0, &rus);
+	return rus.ru_utime.tv_sec * 1000 + rus.ru_utime.tv_usec / 1000;
+}
+#endif
+
+/*///////////////////////////////////////////////////////////////////////////*/
+
+mpf_t t1, t2;
+
+/* r = sqrt(x) */
+void
+my_sqrt_ui(mpf_t r, unsigned long x)
+{
+	unsigned long prec, bits, prec0;
+
+	prec0 = mpf_get_prec(r);
+
+	if (prec0 <= DOUBLE_PREC) {
+		mpf_set_d(r, sqrt(x));
+		return;
+	}
+
+	bits = 0;
+	for (prec = prec0; prec>DOUBLE_PREC;)
+	{
+		int bit = prec & 1;
+		prec = (prec + bit) / 2;
+		bits = bits * 2 + bit;
+	}
+
+	mpf_set_prec_raw(t1, DOUBLE_PREC);
+	mpf_set_d(t1, 1 / sqrt(x));
+
+	while (prec<prec0)
+	{
+		prec *= 2;
+		if (prec<prec0)
+		{
+			/* t1 = t1+t1*(1-x*t1*t1)/2; */
+			mpf_set_prec_raw(t2, prec);
+			mpf_mul(t2, t1, t1);         /* half x half -> full */
+			mpf_mul_ui(t2, t2, x);
+			mpf_ui_sub(t2, 1, t2);
+			mpf_set_prec_raw(t2, prec / 2);
+			mpf_div_2exp(t2, t2, 1);
+			mpf_mul(t2, t2, t1);         /* half x half -> half */
+			mpf_set_prec_raw(t1, prec);
+			mpf_add(t1, t1, t2);
+		}
+		else
+		{
+			break;
+		}
+		prec -= (bits & 1);
+		bits /= 2;
+	}
+	/* t2=x*t1, t1 = t2+t1*(x-t2*t2)/2; */
+	mpf_set_prec_raw(t2, prec0 / 2);
+	mpf_mul_ui(t2, t1, x);
+	mpf_mul(r, t2, t2);          /* half x half -> full */
+	mpf_ui_sub(r, x, r);
+	mpf_mul(t1, t1, r);          /* half x half -> half */
+	mpf_div_2exp(t1, t1, 1);
+	mpf_add(r, t1, t2);
+}
+
+/* r = y/x   WARNING: r cannot be the same as y. */
+#if __GMP_MP_RELEASE >= 50001
+#define my_div mpf_div
+#else
+void
+my_div(mpf_t r, mpf_t y, mpf_t x)
+{
+	unsigned long prec, bits, prec0;
+
+	prec0 = mpf_get_prec(r);
+
+	if (prec0 <= DOUBLE_PREC) {
+		mpf_set_d(r, mpf_get_d(y) / mpf_get_d(x));
+		return;
+	}
+
+	bits = 0;
+	for (prec = prec0; prec>DOUBLE_PREC;) {
+		int bit = prec & 1;
+		prec = (prec + bit) / 2;
+		bits = bits * 2 + bit;
+	}
+
+	mpf_set_prec_raw(t1, DOUBLE_PREC);
+	mpf_ui_div(t1, 1, x);
+
+	while (prec<prec0) {
+		prec *= 2;
+		if (prec<prec0) {
+			/* t1 = t1+t1*(1-x*t1); */
+			mpf_set_prec_raw(t2, prec);
+			mpf_mul(t2, x, t1);          /* full x half -> full */
+			mpf_ui_sub(t2, 1, t2);
+			mpf_set_prec_raw(t2, prec / 2);
+			mpf_mul(t2, t2, t1);         /* half x half -> half */
+			mpf_set_prec_raw(t1, prec);
+			mpf_add(t1, t1, t2);
+		}
+		else {
+			prec = prec0;
+			/* t2=y*t1, t1 = t2+t1*(y-x*t2); */
+			mpf_set_prec_raw(t2, prec / 2);
+			mpf_mul(t2, t1, y);          /* half x half -> half */
+			mpf_mul(r, x, t2);           /* full x half -> full */
+			mpf_sub(r, y, r);
+			mpf_mul(t1, t1, r);          /* half x half -> half */
+			mpf_add(r, t1, t2);
+			break;
+		}
+		prec -= (bits & 1);
+		bits /= 2;
+	}
+}
+#endif
+
+/*///////////////////////////////////////////////////////////////////////////*/
+
+#define min(x,y) ((x)<(y)?(x):(y))
+#define max(x,y) ((x)>(y)?(x):(y))
+
+typedef struct fac_str {
+	unsigned long max_facs;
+	unsigned long num_facs;
+	unsigned long *fac;
+	unsigned long *pow;
+} fac_t[1];
+
+typedef struct {
+	long int fac;
+	long int pow;
+	long int nxt;
+} sieve_t;
+
+sieve_t *sieve;
+long int sieve_size;
+fac_t   ftmp, fmul;
+
+#define INIT_FACS 32
+
+void
+fac_show(fac_t f)
+{
+	long int i;
+	for (i = 0; i<f[0].num_facs; i++)
+		if (f[0].pow[i] == 1)
+			printf("%ld ", f[0].fac[i]);
+		else
+			printf("%ld^%ld ", f[0].fac[i], f[0].pow[i]);
+	printf("\n");
+}
+
+inline void
+fac_reset(fac_t f)
+{
+	f[0].num_facs = 0;
+}
+
+inline void
+fac_init_size(fac_t f, long int s)
+{
+	if (s<INIT_FACS)
+		s = INIT_FACS;
+
+	f[0].fac = (unsigned long *)malloc(s * sizeof(unsigned long) * 2);
+	f[0].pow = f[0].fac + s;
+	f[0].max_facs = s;
+
+	fac_reset(f);
+}
+
+inline void
+fac_init(fac_t f)
+{
+	fac_init_size(f, INIT_FACS);
+}
+
+inline void
+fac_clear(fac_t f)
+{
+	free(f[0].fac);
+}
+
+inline void
+fac_resize(fac_t f, long int s)
+{
+	if (f[0].max_facs < s) {
+		fac_clear(f);
+		fac_init_size(f, s);
+	}
+}
+
+/* f = base^pow */
+inline void
+fac_set_bp(fac_t f, unsigned long base, long int pow)
+{
+	long int i;
+	assert(base<sieve_size);
+	for (i = 0, base /= 2; base>0; i++, base = sieve[base].nxt) {
+		f[0].fac[i] = sieve[base].fac;
+		f[0].pow[i] = sieve[base].pow*pow;
+	}
+	f[0].num_facs = i;
+	assert(i <= f[0].max_facs);
+}
+
+/* r = f*g */
+inline void
+fac_mul2(fac_t r, fac_t f, fac_t g)
+{
+	long int i, j, k;
+
+	for (i = j = k = 0; i<f[0].num_facs && j<g[0].num_facs; k++) {
+		if (f[0].fac[i] == g[0].fac[j]) {
+			r[0].fac[k] = f[0].fac[i];
+			r[0].pow[k] = f[0].pow[i] + g[0].pow[j];
+			i++; j++;
+		}
+		else if (f[0].fac[i] < g[0].fac[j]) {
+			r[0].fac[k] = f[0].fac[i];
+			r[0].pow[k] = f[0].pow[i];
+			i++;
+		}
+		else {
+			r[0].fac[k] = g[0].fac[j];
+			r[0].pow[k] = g[0].pow[j];
+			j++;
+		}
+	}
+	for (; i<f[0].num_facs; i++, k++) {
+		r[0].fac[k] = f[0].fac[i];
+		r[0].pow[k] = f[0].pow[i];
+	}
+	for (; j<g[0].num_facs; j++, k++) {
+		r[0].fac[k] = g[0].fac[j];
+		r[0].pow[k] = g[0].pow[j];
+	}
+	r[0].num_facs = k;
+	assert(k <= r[0].max_facs);
+}
+
+/* f *= g */
+inline void
+fac_mul(fac_t f, fac_t g)
+{
+	fac_t tmp;
+	fac_resize(fmul, f[0].num_facs + g[0].num_facs);
+	fac_mul2(fmul, f, g);
+	tmp[0] = f[0];
+	f[0] = fmul[0];
+	fmul[0] = tmp[0];
+}
+
+/* f *= base^pow */
+inline void
+fac_mul_bp(fac_t f, unsigned long base, unsigned long pow)
+{
+	fac_set_bp(ftmp, base, pow);
+	fac_mul(f, ftmp);
+}
+
+/* remove factors of power 0 */
+inline void
+fac_compact(fac_t f)
+{
+	long int i, j;
+	for (i = 0, j = 0; i<f[0].num_facs; i++) {
+		if (f[0].pow[i]>0) {
+			if (j<i) {
+				f[0].fac[j] = f[0].fac[i];
+				f[0].pow[j] = f[0].pow[i];
+			}
+			j++;
+		}
+	}
+	f[0].num_facs = j;
+}
+
+/* convert factorized form to number */
+void
+bs_mul(mpz_t r, long int a, long int b)
+{
+	long int i, j;
+	if (b - a <= 32) {
+		mpz_set_ui(r, 1);
+		for (i = a; i<b; i++)
+			for (j = 0; j<fmul[0].pow[i]; j++)
+				mpz_mul_ui(r, r, fmul[0].fac[i]);
+	}
+	else {
+		mpz_t r2;
+		mpz_init(r2);
+		bs_mul(r2, a, (a + b) / 2);
+		bs_mul(r, (a + b) / 2, b);
+		mpz_mul(r, r, r2);
+		mpz_clear(r2);
+	}
+}
+
+mpz_t    gcd, mgcd;
+
+#if HAVE_DIVEXACT_PREINV
+void mpz_invert_mod_2exp(mpz_ptr, mpz_srcptr);
+void mpz_divexact_pre(mpz_ptr, mpz_srcptr, mpz_srcptr, mpz_srcptr);
+
+#endif
+
+/* f /= gcd(f,g), g /= gcd(f,g) */
+void
+fac_remove_gcd(mpz_t p, fac_t fp, mpz_t g, fac_t fg)
+{
+	long int i, j, k, c;
+	fac_resize(fmul, min(fp->num_facs, fg->num_facs));
+	for (i = j = k = 0; i<fp->num_facs && j<fg->num_facs; ) {
+		if (fp->fac[i] == fg->fac[j]) {
+			c = min(fp->pow[i], fg->pow[j]);
+			fp->pow[i] -= c;
+			fg->pow[j] -= c;
+			fmul->fac[k] = fp->fac[i];
+			fmul->pow[k] = c;
+			i++; j++; k++;
+		}
+		else if (fp->fac[i] < fg->fac[j]) {
+			i++;
+		}
+		else {
+			j++;
+		}
+	}
+	fmul->num_facs = k;
+	assert(k <= fmul->max_facs);
+
+	if (fmul->num_facs) {
+		bs_mul(gcd, 0, fmul->num_facs);
+#if HAVE_DIVEXACT_PREINV
+		mpz_invert_mod_2exp(mgcd, gcd);
+		mpz_divexact_pre(p, p, gcd, mgcd);
+		mpz_divexact_pre(g, g, gcd, mgcd);
+#else
+#define SIZ(x) x->_mp_size
+		mpz_divexact(p, p, gcd);
+		mpz_divexact(g, g, gcd);
+#endif
+		fac_compact(fp);
+		fac_compact(fg);
+	}
+}
+
+/*///////////////////////////////////////////////////////////////////////////*/
+
+int      out = 0;
+mpz_t   *pstack, *qstack, *gstack;
+fac_t  *fpstack, *fgstack;
+long int      top = 0;
+double   progress = 0, percent;
+
+#define p1 (pstack[top])
+#define q1 (qstack[top])
+#define g1 (gstack[top])
+#define fp1 (fpstack[top])
+#define fg1 (fgstack[top])
+
+#define p2 (pstack[top+1])
+#define q2 (qstack[top+1])
+#define g2 (gstack[top+1])
+#define fp2 (fpstack[top+1])
+#define fg2 (fgstack[top+1])
+
+long gcd_time = 0;
+
+/* binary splitting */
+void
+bs(unsigned long a, unsigned long b, unsigned gflag, long int level)
+{
+	unsigned long i, mid;
+	int ccc;
+
+	if (b - a == 1) {
+		/*
+		g(b-1,b) = (6b-5)(2b-1)(6b-1)
+		p(b-1,b) = b^3 * C^3 / 24
+		q(b-1,b) = (-1)^b*g(b-1,b)*(A+Bb).
+		*/
+		mpz_set_ui(p1, b);
+		mpz_mul_ui(p1, p1, b);
+		mpz_mul_ui(p1, p1, b);
+		mpz_mul_ui(p1, p1, (C / 24)*(C / 24));
+		mpz_mul_ui(p1, p1, C * 24);
+
+		mpz_set_ui(g1, 2 * b - 1);
+		mpz_mul_ui(g1, g1, 6 * b - 1);
+		mpz_mul_ui(g1, g1, 6 * b - 5);
+
+		mpz_set_ui(q1, b);
+		mpz_mul_ui(q1, q1, B);
+		mpz_add_ui(q1, q1, A);
+		mpz_mul(q1, q1, g1);
+		if (b % 2)
+			mpz_neg(q1, q1);
+
+		i = b;
+		while ((i & 1) == 0) i >>= 1;
+		fac_set_bp(fp1, i, 3);	/*  b^3 */
+		fac_mul_bp(fp1, 3 * 5 * 23 * 29, 3);
+		fp1[0].pow[0]--;
+
+		fac_set_bp(fg1, 2 * b - 1, 1);	/* 2b-1 */
+		fac_mul_bp(fg1, 6 * b - 1, 1);	/* 6b-1 */
+		fac_mul_bp(fg1, 6 * b - 5, 1);	/* 6b-5 */
+
+		if (b>(int)(progress)) {
+			printf("."); fflush(stdout);
+			progress += percent * 2;
+		}
+
+	}
+	else {
+		/*
+		p(a,b) = p(a,m) * p(m,b)
+		g(a,b) = g(a,m) * g(m,b)
+		q(a,b) = q(a,m) * p(m,b) + q(m,b) * g(a,m)
+		*/
+		mid = a + (b - a)*0.5224;     /* tuning parameter */
+		bs(a, mid, 1, level + 1);
+
+		top++;
+		bs(mid, b, gflag, level + 1);
+		top--;
+
+		if (level == 0)
+			puts("");
+
+		ccc = level == 0;
+
+		if (ccc) CHECK_MEMUSAGE;
+
+		if (level >= 4) {           /* tuning parameter */
+#if 0
+			long t = cputime();
+#endif
+			fac_remove_gcd(p2, fp2, g1, fg1);
+#if 0
+			gcd_time += cputime() - t;
+#endif
+		}
+
+		if (ccc) CHECK_MEMUSAGE;
+		mpz_mul(p1, p1, p2);
+
+		if (ccc) CHECK_MEMUSAGE;
+		mpz_mul(q1, q1, p2);
+
+		if (ccc) CHECK_MEMUSAGE;
+		mpz_mul(q2, q2, g1);
+
+		if (ccc) CHECK_MEMUSAGE;
+		mpz_add(q1, q1, q2);
+
+		if (ccc) CHECK_MEMUSAGE;
+		fac_mul(fp1, fp2);
+
+		if (gflag) {
+			mpz_mul(g1, g1, g2);
+			fac_mul(fg1, fg2);
+		}
+	}
+
+	if (out & 2) {
+		printf("p(%ld,%ld)=", a, b); fac_show(fp1);
+		if (gflag)
+			printf("g(%ld,%ld)=", a, b); fac_show(fg1);
+	}
+}
+
+void
+build_sieve(long int n, sieve_t *s)
+{
+	long int m, i, j, k;
+
+	sieve_size = n;
+	m = (long int)sqrt(n);
+	memset(s, 0, sizeof(sieve_t)*n / 2);
+
+	s[1 / 2].fac = 1;
+	s[1 / 2].pow = 1;
+
+	for (i = 3; i <= n; i += 2) {
+		if (s[i / 2].fac == 0) {
+			s[i / 2].fac = i;
+			s[i / 2].pow = 1;
+			if (i <= m) {
+				for (j = i*i, k = i / 2; j <= n; j += i + i, k++) {
+					if (s[j / 2].fac == 0) {
+						s[j / 2].fac = i;
+						if (s[k].fac == i) {
+							s[j / 2].pow = s[k].pow + 1;
+							s[j / 2].nxt = s[k].nxt;
+						}
+						else {
+							s[j / 2].pow = 1;
+							s[j / 2].nxt = k;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	mpf_t  pi, qi;
+	long int d = 100, i, depth = 1, terms;
+	unsigned long psize, qsize;
+	long begin, mid0, mid1, mid2, mid3, mid4, end;
+
+	prog_name = argv[0];
+
+	if (argc>1)
+		d = strtoul(argv[1], 0, 0);
+	if (argc>2)
+		out = atoi(argv[2]);
+
+	terms = d / DIGITS_PER_ITER;
+	while ((1L << depth)<terms)
+		depth++;
+	depth++;
+	percent = terms / 100.0;
+	printf("#terms=%ld, depth=%ld\n", terms, depth);
+
+	begin = cputime();
+	printf("sieve   "); fflush(stdout);
+
+	sieve_size = max(3 * 5 * 23 * 29 + 1, terms * 6);
+	sieve = (sieve_t *)malloc(sizeof(sieve_t)*sieve_size / 2);
+	build_sieve(sieve_size, sieve);
+
+	mid0 = cputime();
+	printf("time = %6.3f\n", (double)(mid0 - begin) / 1000);
+
+	/* allocate stacks */
+	pstack = (mpz_t   *)malloc(sizeof(mpz_t)*depth);
+	qstack = (mpz_t   *)malloc(sizeof(mpz_t)*depth);
+	gstack = (mpz_t   *)malloc(sizeof(mpz_t)*depth);
+	fpstack = (fac_t  *)malloc(sizeof(fac_t)*depth);
+	fgstack = (fac_t  *)malloc(sizeof(fac_t)*depth);
+	for (i = 0; i<depth; i++) {
+		mpz_init(pstack[i]);
+		mpz_init(qstack[i]);
+		mpz_init(gstack[i]);
+		fac_init(fpstack[i]);
+		fac_init(fgstack[i]);
+	}
+	mpz_init(gcd);
+#if HAVE_DIVEXACT_PREINV
+	mpz_init(mgcd);
+#endif
+	fac_init(ftmp);
+	fac_init(fmul);
+
+	/* begin binary splitting process */
+	if (terms <= 0) {
+		mpz_set_ui(p2, 1);
+		mpz_set_ui(q2, 0);
+		mpz_set_ui(g2, 1);
+	}
+	else {
+		bs(0, terms, 0, 0);
+	}
+
+	mid1 = cputime();
+	printf("\nbs      time = %6.3f\n", (double)(mid1 - mid0) / 1000);
+	printf("   gcd  time = %6.3f\n", (double)(gcd_time) / 1000);
+
+	/* printf("misc    "); fflush(stdout); */
+
+	/* free some resources */
+	free(sieve);
+
+#if HAVE_DIVEXACT_PREINV
+	mpz_clear(mgcd);
+#endif
+	mpz_clear(gcd);
+	fac_clear(ftmp);
+	fac_clear(fmul);
+
+	for (i = 1; i<depth; i++) {
+		mpz_clear(pstack[i]);
+		mpz_clear(qstack[i]);
+		mpz_clear(gstack[i]);
+		fac_clear(fpstack[i]);
+		fac_clear(fgstack[i]);
+	}
+
+	mpz_clear(gstack[0]);
+	fac_clear(fpstack[0]);
+	fac_clear(fgstack[0]);
+
+	free(gstack);
+	free(fpstack);
+	free(fgstack);
+
+	/* prepare to convert integers to floats */
+	mpf_set_default_prec((long int)(d*BITS_PER_DIGIT + 16));
+
+	/*
+	p*(C/D)*sqrt(C)
+	pi = -----------------
+	(q+A*p)
+	*/
+
+	psize = mpz_sizeinbase(p1, 10);
+	qsize = mpz_sizeinbase(q1, 10);
+
+	mpz_addmul_ui(q1, p1, A);
+	mpz_mul_ui(p1, p1, C / D);
+
+	mpf_init(pi);
+	mpf_set_z(pi, p1);
+	mpz_clear(p1);
+
+	mpf_init(qi);
+	mpf_set_z(qi, q1);
+	mpz_clear(q1);
+
+	free(pstack);
+	free(qstack);
+
+	mid2 = cputime();
+	/* printf("time = %6.3f\n", (double)(mid2-mid1)/1000); */
+
+	/* initialize temp float variables for sqrt & div */
+	mpf_init(t1);
+	mpf_init(t2);
+	/* mpf_set_prec_raw(t1, mpf_get_prec(pi)); */
+
+	/* final step */
+	printf("div     ");  fflush(stdout);
+	my_div(qi, pi, qi);
+	mid3 = cputime();
+	printf("time = %6.3f\n", (double)(mid3 - mid2) / 1000);
+
+	printf("sqrt    ");  fflush(stdout);
+	my_sqrt_ui(pi, C);
+	mid4 = cputime();
+	printf("time = %6.3f\n", (double)(mid4 - mid3) / 1000);
+
+	printf("mul     ");  fflush(stdout);
+	mpf_mul(qi, qi, pi);
+	end = cputime();
+	printf("time = %6.3f\n", (double)(end - mid4) / 1000);
+
+	printf("total   time = %6.3f\n", (double)(end - begin) / 1000);
+	fflush(stdout);
+
+	printf("   P size=%ld digits (%f)\n"
+		"   Q size=%ld digits (%f)\n",
+		psize, (double)psize / d, qsize, (double)qsize / d);
+
+	/* output Pi and timing statistics */
+	if (out & 1) {
+		printf("pi(0,%ld)=\n", terms);
+		mpf_out_str(stdout, 10, d + 2, qi);
+		printf("\n");
+	}
+
+	/* free float resources */
+	mpf_clear(pi);
+	mpf_clear(qi);
+
+	mpf_clear(t1);
+	mpf_clear(t2);
+	return 0;
+}

--- a/mpn/generic/mul_basecase.c
+++ b/mpn/generic/mul_basecase.c
@@ -35,6 +35,8 @@ see https://www.gnu.org/licenses/.  */
 #include "gmp.h"
 #include "gmp-impl.h"
 
+#define HAVE_NATIVE_mpn_addmul_2 1
+#define HAVE_NATIVE_mpn_mul_2 1
 
 /* Multiply {up,usize} by {vp,vsize} and write the result to
    {prodp,usize+vsize}.  Must have usize>=vsize.


### PR DESCRIPTION
I add test Pi program. This program computes 10 mln digits of Pi with generic *.c in 21.255 s. I added new project and asm files from MPIR.  Speedup to 8.546 s. Not added quite big file mul_basecase.asm - is error when I tried replace. If would possible use this file, will better speedup.
